### PR TITLE
Add Flask-based wiki board with markdown and tag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.db
+instance/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Wiki Board
+
+Simple wiki-style bulletin board built with Flask and SQLite. Supports user registration and login, Markdown posts, and global tagging with per-user permissions.
+
+## Features
+- User registration and login with role support (admin/user)
+- Create and edit Markdown posts
+- Global tag management; posts can be filtered by tags
+- Permissions: authors or admins can edit posts
+
+## Requirements
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+```bash
+python app.py
+```
+The application creates `wiki.db` SQLite database on first run.
+
+Open browser at `http://127.0.0.1:5000/`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,169 @@
+import markdown
+from flask import Flask, render_template, redirect, url_for, request, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import (LoginManager, login_user, login_required,
+                         logout_user, current_user, UserMixin)
+from werkzeug.security import generate_password_hash, check_password_hash
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'dev-secret'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///wiki.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='user')
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    def is_admin(self) -> bool:
+        return self.role == 'admin'
+
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    author_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    author = db.relationship('User', backref='posts')
+    tags = db.relationship('Tag', secondary='post_tag', backref='posts')
+
+
+class Tag(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+
+
+class PostTag(db.Model):
+    __tablename__ = 'post_tag'
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), primary_key=True)
+    tag_id = db.Column(db.Integer, db.ForeignKey('tag.id'), primary_key=True)
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    return User.query.get(int(user_id))
+
+
+@app.route('/')
+def index():
+    posts = Post.query.order_by(Post.id.desc()).all()
+    return render_template('index.html', posts=posts)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists')
+            return redirect(url_for('register'))
+        user = User(username=username)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful. Please log in.')
+        return redirect(url_for('login'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+
+@app.route('/post/new', methods=['GET', 'POST'])
+@login_required
+def create_post():
+    if request.method == 'POST':
+        title = request.form['title']
+        body = request.form['body']
+        tag_names = [t.strip() for t in request.form['tags'].split(',') if t.strip()]
+        tags = []
+        for name in tag_names:
+            tag = Tag.query.filter_by(name=name).first()
+            if not tag:
+                tag = Tag(name=name)
+                db.session.add(tag)
+            tags.append(tag)
+        post = Post(title=title, body=body, author=current_user, tags=tags)
+        db.session.add(post)
+        db.session.commit()
+        return redirect(url_for('post_detail', post_id=post.id))
+    return render_template('post_form.html', action='Create')
+
+
+@app.route('/post/<int:post_id>')
+def post_detail(post_id: int):
+    post = Post.query.get_or_404(post_id)
+    html_body = markdown.markdown(post.body)
+    return render_template('post_detail.html', post=post, html_body=html_body)
+
+
+@app.route('/post/<int:post_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit_post(post_id: int):
+    post = Post.query.get_or_404(post_id)
+    if current_user.id != post.author_id and not current_user.is_admin():
+        flash('Permission denied.')
+        return redirect(url_for('post_detail', post_id=post.id))
+    if request.method == 'POST':
+        post.title = request.form['title']
+        post.body = request.form['body']
+        tag_names = [t.strip() for t in request.form['tags'].split(',') if t.strip()]
+        post.tags = []
+        for name in tag_names:
+            tag = Tag.query.filter_by(name=name).first()
+            if not tag:
+                tag = Tag(name=name)
+                db.session.add(tag)
+            post.tags.append(tag)
+        db.session.commit()
+        return redirect(url_for('post_detail', post_id=post.id))
+    tags_str = ', '.join([t.name for t in post.tags])
+    return render_template('post_form.html', action='Edit', post=post, tags=tags_str)
+
+
+@app.route('/tags')
+def tag_list():
+    tags = Tag.query.order_by(Tag.name).all()
+    return render_template('tag_list.html', tags=tags)
+
+
+@app.route('/tag/<string:name>')
+def tag_filter(name: str):
+    tag = Tag.query.filter_by(name=name).first_or_404()
+    return render_template('index.html', posts=tag.posts, tag=tag)
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=3.0.0
+Flask-Login>=0.6.3
+Flask-SQLAlchemy>=3.0.5
+markdown>=3.5.1

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav a { margin-right: 10px; }
+textarea { width: 100%; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Wiki Board{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<nav>
+  <a href="{{ url_for('index') }}">Home</a> |
+  <a href="{{ url_for('tag_list') }}">Tags</a> |
+  {% if current_user.is_authenticated %}
+    <a href="{{ url_for('create_post') }}">New Post</a> |
+    <span>{{ current_user.username }}</span> |
+    <a href="{{ url_for('logout') }}">Logout</a>
+  {% else %}
+    <a href="{{ url_for('login') }}">Login</a> |
+    <a href="{{ url_for('register') }}">Register</a>
+  {% endif %}
+</nav>
+<hr>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul>
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Posts{% endblock %}
+{% block content %}
+<h1>{% if tag %}Posts tagged "{{ tag.name }}"{% else %}All Posts{% endif %}</h1>
+<ul>
+  {% for post in posts %}
+    <li><a href="{{ url_for('post_detail', post_id=post.id) }}">{{ post.title }}</a> by {{ post.author.username }}</li>
+  {% else %}
+    <li>No posts yet.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  <p><input name="username" placeholder="Username"></p>
+  <p><input type="password" name="password" placeholder="Password"></p>
+  <p><button type="submit">Login</button></p>
+</form>
+{% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}{{ post.title }}{% endblock %}
+{% block content %}
+<h1>{{ post.title }}</h1>
+<div>{{ html_body|safe }}</div>
+<p>Tags:
+  {% for tag in post.tags %}
+    <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
+  {% endfor %}
+</p>
+{% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
+  <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
+{% endif %}
+{% endblock %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}{{ action }} Post{% endblock %}
+{% block content %}
+<h1>{{ action }} Post</h1>
+<form method="post">
+  <p><input name="title" placeholder="Title" value="{{ post.title if post else '' }}"></p>
+  <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
+  <p><input name="tags" placeholder="Comma separated tags" value="{{ tags if tags else '' }}"></p>
+  <p><button type="submit">{{ action }}</button></p>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h1>Register</h1>
+<form method="post">
+  <p><input name="username" placeholder="Username"></p>
+  <p><input type="password" name="password" placeholder="Password"></p>
+  <p><button type="submit">Register</button></p>
+</form>
+{% endblock %}

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Tags{% endblock %}
+{% block content %}
+<h1>Tags</h1>
+<ul>
+  {% for tag in tags %}
+    <li><a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a></li>
+  {% else %}
+    <li>No tags yet.</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Create Flask application with SQLite backend, user roles, markdown posts, and global tags
- Provide HTML templates and CSS for basic wiki-style board
- Include requirements and usage documentation

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a042d615d883298251f23af6e25a8d