### PR TITLE
Add hierarchical document paths with multilingual linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Wiki Board
 
-Simple wiki-style bulletin board built with Flask and SQLite. Supports user registration and login, Markdown posts, and global tagging with per-user permissions.
+Simple wiki-style bulletin board built with Flask and SQLite. Supports user registration and login, Markdown posts, global tagging, hierarchical paths, and multilingual linking with per-user permissions.
 
 ## Features
 - User registration and login with role support (admin/user)
 - Create and edit Markdown posts
 - Global tag management; posts can be filtered by tags
+- Hierarchical document paths using `/docs/<lang>/<path>` addresses
+- Link posts written in different languages that share the same path
 - Permissions: authors or admins can edit posts
 
 ## Requirements

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 <h1>{% if tag %}Posts tagged "{{ tag.name }}"{% else %}All Posts{% endif %}</h1>
 <ul>
   {% for post in posts %}
-    <li><a href="{{ url_for('post_detail', post_id=post.id) }}">{{ post.title }}</a> by {{ post.author.username }}</li>
+    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}) by {{ post.author.username }}</li>
   {% else %}
     <li>No posts yet.</li>
   {% endfor %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,13 +1,21 @@
 {% extends "base.html" %}
 {% block title %}{{ post.title }}{% endblock %}
 {% block content %}
-<h1>{{ post.title }}</h1>
+<h1>{{ post.title }} ({{ post.language }})</h1>
+<p><small>{{ post.path }}</small></p>
 <div>{{ html_body|safe }}</div>
 <p>Tags:
   {% for tag in post.tags %}
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
+{% if translations %}
+<p>Other languages:
+  {% for t in translations %}
+    <a href="{{ url_for('document', language=t.language, doc_path=t.path) }}">{{ t.language }}</a>
+  {% endfor %}
+</p>
+{% endif %}
 {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
   <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
 {% endif %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -5,6 +5,8 @@
 <form method="post">
   <p><input name="title" placeholder="Title" value="{{ post.title if post else '' }}"></p>
   <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
+  <p><input name="path" placeholder="Path (e.g., docs/start)" value="{{ post.path if post else '' }}"></p>
+  <p><input name="language" placeholder="Language code" value="{{ post.language if post else 'en' }}"></p>
   <p><input name="tags" placeholder="Comma separated tags" value="{{ tags if tags else '' }}"></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>


### PR DESCRIPTION
## Summary
- Extend posts with path and language fields to support hierarchy and translations
- Provide `/docs/<lang>/<path>` route and translation links between languages
- Update forms and views to capture path, language and show them in templates

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a043c51bf88329bf1231d108b7b7c4