### PR TITLE
Add wiki links and revision history

### DIFF
--- a/templates/diff.html
+++ b/templates/diff.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Diff - {{ post.title }}{% endblock %}
+{% block content %}
+<h1>Diff for {{ post.title }}</h1>
+<pre>{{ diff }}</pre>
+<p><a href="{{ url_for('history', post_id=post.id) }}">Back to history</a></p>
+{% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}History - {{ post.title }}{% endblock %}
+{% block content %}
+<h1>History for {{ post.title }}</h1>
+<ul>
+  {% for rev in revisions %}
+    <li>{{ rev.created_at }} by {{ rev.user.username }} -
+      <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">diff</a>
+    </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -16,7 +16,10 @@
   {% endfor %}
 </p>
 {% endif %}
-{% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
-  <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
-{% endif %}
+<p>
+  <a href="{{ url_for('history', post_id=post.id) }}">History</a>
+  {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
+    | <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
+  {% endif %}
+</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support internal wiki links using `[[Page|Text]]` syntax
- record post revisions with user and timestamp
- add history and diff views to inspect changes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0452b089083298eea082b3e233f5c