### PR TITLE
Add wiki links and revision history

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+
+db = SQLAlchemy()
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='user')
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    def is_admin(self) -> bool:
+        return self.role == 'admin'
+
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    path = db.Column(db.String(200), nullable=False)
+    language = db.Column(db.String(8), nullable=False, default='en')
+    author_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    author = db.relationship('User', backref='posts')
+    tags = db.relationship('Tag', secondary='post_tag', backref='posts')
+    __table_args__ = (
+        db.UniqueConstraint('path', 'language', name='uix_path_language'),
+    )
+
+
+class Tag(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+
+
+class PostTag(db.Model):
+    __tablename__ = 'post_tag'
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), primary_key=True)
+    tag_id = db.Column(db.Integer, db.ForeignKey('tag.id'), primary_key=True)
+
+
+class Revision(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    path = db.Column(db.String(200), nullable=False)
+    language = db.Column(db.String(8), nullable=False, default='en')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User')
+    post = db.relationship('Post', backref='revisions')

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Diff - {{ post.title }}{% endblock %}
+{% block content %}
+<h1>Diff for {{ post.title }}</h1>
+<pre>{{ diff }}</pre>
+<p><a href="{{ url_for('history', post_id=post.id) }}">Back to history</a></p>
+{% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}History - {{ post.title }}{% endblock %}
+{% block content %}
+<h1>History for {{ post.title }}</h1>
+<ul>
+  {% for rev in revisions %}
+    <li>{{ rev.created_at }} by {{ rev.user.username }} -
+      <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">diff</a>
+    </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -16,7 +16,10 @@
   {% endfor %}
 </p>
 {% endif %}
-{% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
-  <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
-{% endif %}
+<p>
+  <a href="{{ url_for('history', post_id=post.id) }}">History</a>
+  {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
+    | <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
+  {% endif %}
+</p>
 {% endblock %}

--- a/wikilinks.py
+++ b/wikilinks.py
@@ -1,0 +1,33 @@
+from xml.etree.ElementTree import Element
+from markdown.extensions import Extension
+from markdown.inlinepatterns import InlineProcessor
+
+
+class WikiLinkInlineProcessor(InlineProcessor):
+    def __init__(self, pattern, base_url):
+        super().__init__(pattern)
+        self.base_url = base_url
+
+    def handleMatch(self, m, data):
+        label = m.group(1)
+        if '|' in label:
+            target, text = label.split('|', 1)
+        else:
+            target = text = label
+        el = Element('a', {'href': f'{self.base_url}{target}'})
+        el.text = text
+        return el, m.start(0), m.end(0)
+
+
+class WikiLinkExtension(Extension):
+    def __init__(self, **kwargs):
+        self.config = {'base_url': ['/docs/', 'Base URL for wiki links']}
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md):
+        base_url = self.getConfig('base_url')
+        md.inlinePatterns.register(
+            WikiLinkInlineProcessor(r'\[\[([^\]]+)\]\]', base_url),
+            'wikilink',
+            75,
+        )


### PR DESCRIPTION
## Summary
- support internal wiki links using `[[Page|Text]]` syntax
- record post revisions with user and timestamp
- add history and diff views to inspect changes
- extract models and wiki link extension into separate modules for clarity

## Testing
- `python -m py_compile app.py models.py wikilinks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0452b089083298eea082b3e233f5c