### PR TITLE
Add metadata fields for posts and per-user data

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -8,6 +8,8 @@
   <p><input name="path" placeholder="Path (e.g., docs/start)" value="{{ post.path if post else '' }}"></p>
   <p><input name="language" placeholder="Language code" value="{{ post.language if post else 'en' }}"></p>
   <p><input name="tags" placeholder="Comma separated tags" value="{{ tags if tags else '' }}"></p>
+  <p><textarea name="metadata" placeholder="Post metadata (JSON)" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea></p>
+  <p><textarea name="user_metadata" placeholder="Your metadata (JSON)" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support global and per-user metadata for posts
- parse JSON metadata in create and edit routes, storing PostMetadata and UserPostMetadata records
- expose metadata fields in the post form template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a04d91b4d88329be8eb2a1c4296501