### PR TITLE
Display post metadata

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -9,6 +9,27 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
+{% if metadata or user_metadata %}
+<section>
+  <h2>Metadata</h2>
+  {% if metadata %}
+  <h3>Common</h3>
+  <ul>
+    {% for key, value in metadata.items() %}
+      <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  {% if user_metadata %}
+  <h3>Your Metadata</h3>
+  <ul>
+    {% for key, value in user_metadata.items() %}
+      <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</section>
+{% endif %}
 {% if translations %}
 <p>Other languages:
   {% for t in translations %}


### PR DESCRIPTION
## Summary
- expose GIS metadata helper and Jinja filter for coordinates
- show post metadata and per-user metadata on document pages
- render metadata sections in post detail template

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a04e43dabc8329b14fafb3185e7555