### PR TITLE
Add metadata-based search for posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -399,6 +399,27 @@ def tag_filter(name: str):
     return render_template('index.html', posts=tag.posts, tag=tag)
 
 
+@app.route('/search')
+def search():
+    key = request.args.get('key', '').strip()
+    value_raw = request.args.get('value', '').strip()
+    posts = None
+    if key and value_raw:
+        try:
+            value = json.loads(value_raw)
+        except ValueError:
+            value = value_raw
+        posts = (
+            Post.query.join(PostMetadata)
+            .filter(
+                PostMetadata.key == key,
+                PostMetadata.value == value,
+            )
+            .all()
+        )
+    return render_template('search.html', posts=posts, key=key, value=value_raw)
+
+
 if __name__ == '__main__':
     with app.app_context():
         PostMetadata.__table__.create(bind=db.engine, checkfirst=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
 <nav>
   <a href="{{ url_for('index') }}">Home</a> |
   <a href="{{ url_for('tag_list') }}">Tags</a> |
+  <a href="{{ url_for('search') }}">Search</a> |
   {% if current_user.is_authenticated %}
     <a href="{{ url_for('create_post') }}">New Post</a> |
     <span>{{ current_user.username }}</span> |

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Search{% endblock %}
+{% block content %}
+<h1>Search Posts</h1>
+<form method="get">
+  <label>Key: <input type="text" name="key" value="{{ key }}"></label>
+  <label>Value: <input type="text" name="value" value="{{ value }}"></label>
+  <button type="submit">Search</button>
+</form>
+{% if posts is not none %}
+<ul>
+  {% for post in posts %}
+    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }})</li>
+  {% else %}
+    <li>No posts found.</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Implement `/search` route to filter posts by metadata key/value using indexed `PostMetadata` queries
- Add search form template and navigation link

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a050b878a483299a94a6fab8fde02f