### PR TITLE
feat: add Crossref citation suggestions

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -5,6 +5,10 @@
 <form method="post">
   <p><input name="title" placeholder="Title" value="{{ post.title if post else '' }}"></p>
   <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
+  {% if post %}
+  <p><button type="button" id="suggest-citations">인용 추천</button></p>
+  <div id="citation-results"></div>
+  {% endif %}
   <p><input name="path" placeholder="Path (e.g., docs/start)" value="{{ post.path if post else '' }}"></p>
   <p><input name="language" placeholder="Language code" value="{{ post.language if post else 'en' }}"></p>
   <p><input name="tags" placeholder="Comma separated tags" value="{{ tags if tags else '' }}"></p>
@@ -12,4 +16,45 @@
   <p><textarea name="user_metadata" placeholder="Your metadata (JSON)" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>
+{% if post %}
+<script>
+document.getElementById('suggest-citations').addEventListener('click', function () {
+  const body = document.querySelector('textarea[name="body"]').value;
+  fetch('{{ url_for('citation_suggest') }}', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({text: body})
+  }).then(r => r.json()).then(data => {
+    const container = document.getElementById('citation-results');
+    container.innerHTML = '';
+    if (!data.results) return;
+    for (const [sentence, cands] of Object.entries(data.results)) {
+      const section = document.createElement('div');
+      const p = document.createElement('p');
+      p.textContent = sentence;
+      section.appendChild(p);
+      cands.forEach(c => {
+        const pre = document.createElement('pre');
+        pre.textContent = c.text;
+        const btn = document.createElement('button');
+        btn.textContent = '저장';
+        btn.addEventListener('click', () => {
+          const fd = new FormData();
+          fd.append('citation_text', c.text);
+          fetch('{{ url_for('new_citation', post_id=post.id) }}', {
+            method: 'POST',
+            body: fd
+          }).then(() => { btn.disabled = true; });
+        });
+        const div = document.createElement('div');
+        div.appendChild(pre);
+        div.appendChild(btn);
+        section.appendChild(div);
+      });
+      container.appendChild(section);
+    }
+  });
+});
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add helper to query Crossref per sentence and return BibTeX suggestions
- expose `/citation/suggest` API that returns sentence-citation candidates
- allow editing form to request suggestions and save chosen citations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0580f1ec08329b7fe76f0352e4995