### PR TITLE
Add markdown preview endpoint with live preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -462,6 +462,14 @@ def document(language: str, doc_path: str):
     )
 
 
+@app.route('/markdown/preview', methods=['POST'])
+def markdown_preview():
+    data = request.get_json() or {}
+    text = data.get('text', '')
+    html = Markup(markdown.markdown(escape(text)))
+    return {'html': str(html)}
+
+
 @app.route('/citation/suggest', methods=['POST'])
 def citation_suggest():
     data = request.get_json() or {}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -5,6 +5,7 @@
 <form method="post">
   <p><input name="title" placeholder="Title" value="{{ post.title if post else '' }}"></p>
   <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
+  <div id="preview"></div>
   {% if post %}
   <p><button type="button" id="suggest-citations">인용 추천</button></p>
   <div id="citation-results"></div>
@@ -16,6 +17,21 @@
   <p><textarea name="user_metadata" placeholder="Your metadata (JSON)" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>
+<script>
+const bodyInput = document.querySelector('textarea[name="body"]');
+const previewEl = document.getElementById('preview');
+function updatePreview() {
+  fetch('{{ url_for('markdown_preview') }}', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({text: bodyInput.value})
+  }).then(r => r.json()).then(data => {
+    previewEl.innerHTML = data.html || '';
+  });
+}
+bodyInput.addEventListener('input', updatePreview);
+updatePreview();
+</script>
 {% if post %}
 <script>
 document.getElementById('suggest-citations').addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- add `/markdown/preview` route to render escaped markdown as safe HTML
- show live markdown preview while editing posts

## Testing
- `python -m py_compile app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a05950489c83299992b17627f9bd70