### PR TITLE
Add document watch notifications

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,8 @@
   <a href="{{ url_for('search') }}">Search</a> |
   <a href="{{ url_for('citation_stats') }}">Citation Stats</a> |
   {% if current_user.is_authenticated %}
+    {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
+    <a href="{{ url_for('notifications') }}">Notifications{% if unread %} ({{ unread }}){% endif %}</a> |
     <a href="{{ url_for('create_post') }}">New Post</a> |
     <span>{{ current_user.username }}</span> |
     <a href="{{ url_for('logout') }}">Logout</a>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Notifications{% endblock %}
+{% block content %}
+<h1>Notifications</h1>
+<ul>
+  {% for n in notifications %}
+    <li{% if n.read_at is none %} style="font-weight:bold"{% endif %}>
+      {{ n.message }} - {{ n.created_at.strftime('%Y-%m-%d %H:%M') }}
+    </li>
+  {% else %}
+    <li>No notifications.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -115,5 +115,17 @@
   {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
     | <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
   {% endif %}
+  {% if current_user.is_authenticated %}
+    {% set watching = post.watchers | selectattr('user_id', 'equalto', current_user.id) | list | length > 0 %}
+    {% if watching %}
+      | <form action="{{ url_for('unwatch_post', post_id=post.id) }}" method="post" style="display:inline">
+        <button type="submit">Unwatch</button>
+      </form>
+    {% else %}
+      | <form action="{{ url_for('watch_post', post_id=post.id) }}" method="post" style="display:inline">
+        <button type="submit">Watch</button>
+      </form>
+    {% endif %}
+  {% endif %}
 </p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `PostWatch` and `Notification` models for tracking watched posts and user alerts
- enable users to watch or unwatch posts and view notifications
- send update notifications to watchers when posts are edited and display notification link in nav bar

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import app
print('OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a05a39f45c8329b8bfb30ff30b8b7e