### PR TITLE
Add Flask-Babel internationalization and ignore compiled catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.db
 instance/
 .env
+
+# Ignore compiled translation catalogs
+*.mo

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,3 @@
+[python: app.py]
+
+[jinja2: templates/**.html]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ habanero>=1.2.2
 bibtexparser>=1.4.0
 
 flask-socketio>=5.3.6
+Flask-Babel>=3.1.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,25 +2,25 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}Wiki Board{% endblock %}</title>
+  <title>{% block title %}{{ _('Wiki Board') }}{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
 <nav>
-  <a href="{{ url_for('index') }}">Home</a> |
-  <a href="{{ url_for('tag_list') }}">Tags</a> |
-  <a href="{{ url_for('search') }}">Search</a> |
-  <a href="{{ url_for('citation_stats') }}">Citation Stats</a> |
+  <a href="{{ url_for('index') }}">{{ _('Home') }}</a> |
+  <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a> |
+  <a href="{{ url_for('search') }}">{{ _('Search') }}</a> |
+  <a href="{{ url_for('citation_stats') }}">{{ _('Citation Stats') }}</a> |
   {% if current_user.is_authenticated %}
     {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
-    <a href="{{ url_for('notifications') }}">Notifications{% if unread %} ({{ unread }}){% endif %}</a> |
-    <a href="{{ url_for('create_post') }}">New Post</a> |
+    <a href="{{ url_for('notifications') }}">{{ _('Notifications') }}{% if unread %} ({{ unread }}){% endif %}</a> |
+    <a href="{{ url_for('create_post') }}">{{ _('New Post') }}</a> |
     <span>{{ current_user.username }}</span> |
-    <a href="{{ url_for('logout') }}">Logout</a>
+    <a href="{{ url_for('logout') }}">{{ _('Logout') }}</a>
   {% else %}
-    <a href="{{ url_for('login') }}">Login</a> |
-    <a href="{{ url_for('register') }}">Register</a>
+    <a href="{{ url_for('login') }}">{{ _('Login') }}</a> |
+    <a href="{{ url_for('register') }}">{{ _('Register') }}</a>
   {% endif %}
 </nav>
 <hr>
@@ -46,8 +46,8 @@
         <p id="ogDescription"></p>
       </div>
       <div class="modal-footer">
-        <a id="ogContinue" href="#" class="btn btn-primary">Continue</a>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <a id="ogContinue" href="#" class="btn btn-primary">{{ _('Continue') }}</a>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
       </div>
     </div>
   </div>
@@ -58,6 +58,7 @@
   const socket = io();
   const currentUserId = {{ current_user.id if current_user.is_authenticated else 'null' }};
   const notifUrl = "{{ url_for('notifications') }}";
+  const notifLabel = "{{ _('Notifications') }}";
 
   socket.on('new_post', data => {
     const list = document.getElementById('post-list');
@@ -77,7 +78,7 @@
       if (link) {
         const match = link.textContent.match(/\((\d+)\)/);
         let count = match ? parseInt(match[1]) + 1 : 1;
-        link.textContent = `Notifications (${count})`;
+        link.textContent = `${notifLabel} (${count})`;
       }
     }
   });

--- a/templates/citation_form.html
+++ b/templates/citation_form.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}{{ action }} Citation{% endblock %}
+{% block title %}{{ _('%(action)s Citation', action=action) }}{% endblock %}
 {% block content %}
-<h1>{{ action }} Citation for {{ post.title }}</h1>
+<h1>{{ _('%(action)s Citation for %(title)s', action=action, title=post.title) }}</h1>
 <form method="post">
-  <p><textarea name="citation_part" placeholder="Citation part (JSON)" rows="5" cols="50">{{ citation_part if citation_part else '' }}</textarea></p>
-  <p><textarea name="citation_text" placeholder="Citation text" rows="5" cols="50">{{ citation.citation_text if citation else '' }}</textarea></p>
+  <p><textarea name="citation_part" placeholder="{{ _('Citation part (JSON)') }}" rows="5" cols="50">{{ citation_part if citation_part else '' }}</textarea></p>
+  <p><textarea name="citation_text" placeholder="{{ _('Citation text') }}" rows="5" cols="50">{{ citation.citation_text if citation else '' }}</textarea></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>
 {% endblock %}

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}Citation Statistics{% endblock %}
+{% block title %}{{ _('Citation Statistics') }}{% endblock %}
 {% block content %}
-<h1>Citation Statistics</h1>
+<h1>{{ _('Citation Statistics') }}</h1>
 <table>
   <tr>
-    <th>DOI / Citation</th>
-    <th>Usage Count</th>
-    <th>Posts</th>
+    <th>{{ _('DOI / Citation') }}</th>
+    <th>{{ _('Usage Count') }}</th>
+    <th>{{ _('Posts') }}</th>
   </tr>
   {% for item in stats %}
   <tr>

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Diff - {{ post.title }}{% endblock %}
+{% block title %}{{ _('Diff') }} - {{ post.title }}{% endblock %}
 {% block content %}
-<h1>Diff for {{ post.title }}</h1>
+<h1>{{ _('Diff for %(title)s', title=post.title) }}</h1>
 <pre>{{ diff }}</pre>
-<p><a href="{{ url_for('history', post_id=post.id) }}">Back to history</a></p>
+<p><a href="{{ url_for('history', post_id=post.id) }}">{{ _('Back to history') }}</a></p>
 {% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% block title %}History - {{ post.title }}{% endblock %}
+{% block title %}{{ _('History') }} - {{ post.title }}{% endblock %}
 {% block content %}
-<h1>History for {{ post.title }}</h1>
+<h1>{{ _('History for %(title)s', title=post.title) }}</h1>
 <ul>
   {% for rev in revisions %}
-    <li>{{ rev.created_at }} by {{ rev.user.username }} -
-      <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">diff</a>
+    <li>{{ rev.created_at }} {{ _('by') }} {{ rev.user.username }} -
+      <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">{{ _('diff') }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}Posts{% endblock %}
+{% block title %}{{ _('Posts') }}{% endblock %}
 {% block content %}
-<h1>{% if tag %}Posts tagged "{{ tag.name }}"{% else %}All Posts{% endif %}</h1>
+<h1>{% if tag %}{{ _('Posts tagged "%(tag)s"', tag=tag.name) }}{% else %}{{ _('All Posts') }}{% endif %}</h1>
 <ul id="post-list">
   {% for post in posts %}
-    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}) by {{ post.author.username }}</li>
+    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}) {{ _('by') }} {{ post.author.username }}</li>
   {% else %}
-    <li>No posts yet.</li>
+    <li>{{ _('No posts yet.') }}</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Login{% endblock %}
+{% block title %}{{ _('Login') }}{% endblock %}
 {% block content %}
-<h1>Login</h1>
+<h1>{{ _('Login') }}</h1>
 <form method="post">
-  <p><input name="username" placeholder="Username"></p>
-  <p><input type="password" name="password" placeholder="Password"></p>
-  <p><button type="submit">Login</button></p>
+  <p><input name="username" placeholder="{{ _('Username') }}"></p>
+  <p><input type="password" name="password" placeholder="{{ _('Password') }}"></p>
+  <p><button type="submit">{{ _('Login') }}</button></p>
 </form>
 {% endblock %}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
-{% block title %}Notifications{% endblock %}
+{% block title %}{{ _('Notifications') }}{% endblock %}
 {% block content %}
-<h1>Notifications</h1>
+<h1>{{ _('Notifications') }}</h1>
 <ul>
   {% for n in notifications %}
     <li{% if n.read_at is none %} style="font-weight:bold"{% endif %}>
       {{ n.message }} - {{ n.created_at.strftime('%Y-%m-%d %H:%M') }}
     </li>
   {% else %}
-    <li>No notifications.</li>
+    <li>{{ _('No notifications.') }}</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -4,16 +4,16 @@
 <h1>{{ post.title }} ({{ post.language }})</h1>
 <p><small>{{ post.path }}</small></p>
 <div>{{ html_body|safe }}</div>
-<p>Tags:
+<p>{{ _('Tags') }}:
   {% for tag in post.tags %}
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
 {% if metadata or user_metadata %}
 <section>
-  <h2>Metadata</h2>
+  <h2>{{ _('Metadata') }}</h2>
   {% if metadata %}
-  <h3>Common</h3>
+  <h3>{{ _('Common') }}</h3>
   <ul>
     {% for key, value in metadata.items() %}
       <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
@@ -21,7 +21,7 @@
   </ul>
   {% endif %}
   {% if user_metadata %}
-  <h3>Your Metadata</h3>
+  <h3>{{ _('Your Metadata') }}</h3>
   <ul>
     {% for key, value in user_metadata.items() %}
       <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
@@ -32,9 +32,9 @@
 {% endif %}
 {% if citations or user_citations %}
 <section>
-  <h2>Citations</h2>
+  <h2>{{ _('Citations') }}</h2>
   {% if citations %}
-  <h3>Global</h3>
+  <h3>{{ _('Global') }}</h3>
   <ul>
     {% for c in citations %}
       <li>
@@ -43,9 +43,9 @@
         &mdash; {{ c.user.username }},
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
-          <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">Edit</a>
+          <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">{{ _('Edit') }}</a>
           <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" style="display:inline">
-            <button type="submit">Delete</button>
+            <button type="submit">{{ _('Delete') }}</button>
           </form>
         {% endif %}
       </li>
@@ -53,7 +53,7 @@
   </ul>
   {% endif %}
   {% if user_citations %}
-  <h3>Your Citations</h3>
+  <h3>{{ _('Your Citations') }}</h3>
   <ul>
     {% for c in user_citations %}
       <li>
@@ -61,9 +61,9 @@
         {{ c.citation_text }}
         &mdash; {{ c.user.username }},
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
-        <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">Edit</a>
+        <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">{{ _('Edit') }}</a>
         <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" style="display:inline">
-          <button type="submit">Delete</button>
+          <button type="submit">{{ _('Delete') }}</button>
         </form>
       </li>
     {% endfor %}
@@ -73,15 +73,15 @@
 {% endif %}
 {% if current_user.is_authenticated %}
 <section>
-  <h2>Add Citation</h2>
+  <h2>{{ _('Add Citation') }}</h2>
   <form id="citation-form" action="{{ url_for('new_citation', post_id=post.id) }}" method="post">
     <p>
-      <input type="text" id="citation-title" placeholder="Title" />
-      <button type="button" id="fetch-citation">Fetch Citation</button>
+      <input type="text" id="citation-title" placeholder="{{ _('Title') }}" />
+      <button type="button" id="fetch-citation">{{ _('Fetch Citation') }}</button>
     </p>
-    <p><textarea id="citation-part" name="citation_part" placeholder="Citation part (JSON)" rows="4" cols="50"></textarea></p>
-    <p><textarea id="citation-text" name="citation_text" placeholder="Citation text" rows="4" cols="50"></textarea></p>
-    <p><button type="submit">Add Citation</button></p>
+    <p><textarea id="citation-part" name="citation_part" placeholder="{{ _('Citation part (JSON)') }}" rows="4" cols="50"></textarea></p>
+    <p><textarea id="citation-text" name="citation_text" placeholder="{{ _('Citation text') }}" rows="4" cols="50"></textarea></p>
+    <p><button type="submit">{{ _('Add Citation') }}</button></p>
   </form>
   <script>
   document.getElementById('fetch-citation').addEventListener('click', function() {
@@ -104,26 +104,26 @@
 </section>
 {% endif %}
 {% if translations %}
-<p>Other languages:
+<p>{{ _('Other languages') }}:
   {% for t in translations %}
     <a href="{{ url_for('document', language=t.language, doc_path=t.path) }}">{{ t.language }}</a>
   {% endfor %}
 </p>
 {% endif %}
 <p>
-  <a href="{{ url_for('history', post_id=post.id) }}">History</a>
+  <a href="{{ url_for('history', post_id=post.id) }}">{{ _('History') }}</a>
   {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
-    | <a href="{{ url_for('edit_post', post_id=post.id) }}">Edit</a>
+    | <a href="{{ url_for('edit_post', post_id=post.id) }}">{{ _('Edit') }}</a>
   {% endif %}
   {% if current_user.is_authenticated %}
     {% set watching = post.watchers | selectattr('user_id', 'equalto', current_user.id) | list | length > 0 %}
     {% if watching %}
       | <form action="{{ url_for('unwatch_post', post_id=post.id) }}" method="post" style="display:inline">
-        <button type="submit">Unwatch</button>
+        <button type="submit">{{ _('Unwatch') }}</button>
       </form>
     {% else %}
       | <form action="{{ url_for('watch_post', post_id=post.id) }}" method="post" style="display:inline">
-        <button type="submit">Watch</button>
+        <button type="submit">{{ _('Watch') }}</button>
       </form>
     {% endif %}
   {% endif %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
-{% block title %}{{ action }} Post{% endblock %}
+{% block title %}{{ _('%(action)s Post', action=action) }}{% endblock %}
 {% block content %}
-<h1>{{ action }} Post</h1>
+<h1>{{ _('%(action)s Post', action=action) }}</h1>
 <form method="post">
-  <p><input name="title" placeholder="Title" value="{{ post.title if post else '' }}"></p>
+  <p><input name="title" placeholder="{{ _('Title') }}" value="{{ post.title if post else '' }}"></p>
   <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
   <div id="preview"></div>
   {% if post %}
-  <p><button type="button" id="suggest-citations">인용 추천</button></p>
+  <p><button type="button" id="suggest-citations">{{ _('Suggest Citation') }}</button></p>
   <div id="citation-results"></div>
   {% endif %}
-  <p><input name="path" placeholder="Path (e.g., docs/start)" value="{{ post.path if post else '' }}"></p>
-  <p><input name="language" placeholder="Language code" value="{{ post.language if post else 'en' }}"></p>
-  <p><input name="tags" placeholder="Comma separated tags" value="{{ tags if tags else '' }}"></p>
-  <p><textarea name="metadata" placeholder="Post metadata (JSON)" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea></p>
-  <p><textarea name="user_metadata" placeholder="Your metadata (JSON)" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
+  <p><input name="path" placeholder="{{ _('Path (e.g., docs/start)') }}" value="{{ post.path if post else '' }}"></p>
+  <p><input name="language" placeholder="{{ _('Language code') }}" value="{{ post.language if post else 'en' }}"></p>
+  <p><input name="tags" placeholder="{{ _('Comma separated tags') }}" value="{{ tags if tags else '' }}"></p>
+  <p><textarea name="metadata" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea></p>
+  <p><textarea name="user_metadata" placeholder="{{ _('Your metadata (JSON)') }}" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
   <p><button type="submit">{{ action }}</button></p>
 </form>
 <script>
@@ -53,7 +53,7 @@ document.getElementById('suggest-citations').addEventListener('click', function 
         const pre = document.createElement('pre');
         pre.textContent = c.text;
         const btn = document.createElement('button');
-        btn.textContent = '저장';
+        btn.textContent = '{{ _('Save') }}';
         btn.addEventListener('click', () => {
           const fd = new FormData();
           fd.append('citation_text', c.text);

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Register{% endblock %}
+{% block title %}{{ _('Register') }}{% endblock %}
 {% block content %}
-<h1>Register</h1>
+<h1>{{ _('Register') }}</h1>
 <form method="post">
-  <p><input name="username" placeholder="Username"></p>
-  <p><input type="password" name="password" placeholder="Password"></p>
-  <p><button type="submit">Register</button></p>
+  <p><input name="username" placeholder="{{ _('Username') }}"></p>
+  <p><input type="password" name="password" placeholder="{{ _('Password') }}"></p>
+  <p><button type="submit">{{ _('Register') }}</button></p>
 </form>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,18 +1,18 @@
 {% extends "base.html" %}
-{% block title %}Search{% endblock %}
+{% block title %}{{ _('Search') }}{% endblock %}
 {% block content %}
-<h1>Search Posts</h1>
+<h1>{{ _('Search Posts') }}</h1>
 <form method="get">
-  <label>Key: <input type="text" name="key" value="{{ key }}"></label>
-  <label>Value: <input type="text" name="value" value="{{ value }}"></label>
-  <button type="submit">Search</button>
+  <label>{{ _('Key') }}: <input type="text" name="key" value="{{ key }}"></label>
+  <label>{{ _('Value') }}: <input type="text" name="value" value="{{ value }}"></label>
+  <button type="submit">{{ _('Search') }}</button>
 </form>
 {% if posts is not none %}
 <ul>
   {% for post in posts %}
     <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }})</li>
   {% else %}
-    <li>No posts found.</li>
+    <li>{{ _('No posts found.') }}</li>
   {% endfor %}
 </ul>
 {% endif %}

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}Tags{% endblock %}
+{% block title %}{{ _('Tags') }}{% endblock %}
 {% block content %}
-<h1>Tags</h1>
+<h1>{{ _('Tags') }}</h1>
 <ul>
   {% for tag in tags %}
     <li><a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a></li>
   {% else %}
-    <li>No tags yet.</li>
+    <li>{{ _('No tags yet.') }}</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,332 @@
+# Spanish translations for PROJECT.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 10:34+0000\n"
+"PO-Revision-Date: 2025-08-16 10:34+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: app.py:384
+msgid "Username already exists"
+msgstr "El nombre de usuario ya existe"
+
+#: app.py:390
+msgid "Registration successful. Please log in."
+msgstr "Registro exitoso. Por favor inicia sesión."
+
+#: app.py:404
+msgid "Invalid credentials"
+msgstr "Credenciales inválidas"
+
+#: app.py:458 app.py:796
+msgid "Invalid metadata JSON"
+msgstr "JSON de metadatos inválido"
+
+#: app.py:467 app.py:808
+msgid "Invalid user metadata JSON"
+msgstr "JSON de metadatos de usuario inválido"
+
+#: app.py:479
+msgid "Create"
+msgstr "Crear"
+
+#: app.py:603
+msgid "Text is required"
+msgstr "Se requiere texto"
+
+#: app.py:612
+msgid "Title is required"
+msgstr "Se requiere título"
+
+#: app.py:615
+msgid "Citation not found"
+msgstr "Cita no encontrada"
+
+#: app.py:620 app.py:638 app.py:702
+msgid "Failed to parse BibTeX"
+msgstr "Error al analizar BibTeX"
+
+#: app.py:632 app.py:696
+msgid "Citation text is required."
+msgstr "Se requiere texto de cita."
+
+#: app.py:649 app.py:721
+msgid "Citation with this DOI already exists."
+msgstr "Ya existe una cita con este DOI."
+
+#: app.py:656 app.py:737
+msgid "Citation with this text already exists."
+msgstr "Ya existe una cita con este texto."
+
+#: app.py:691 app.py:759 app.py:771
+msgid "Permission denied."
+msgstr "Permiso denegado."
+
+#: app.py:747 app.py:830 templates/post_detail.html:46
+#: templates/post_detail.html:64 templates/post_detail.html:116
+msgid "Edit"
+msgstr "Editar"
+
+#: app.py:820
+#, python-format
+msgid "Post \"%(title)s\" was updated."
+msgstr "La publicación \"%(title)s\" fue actualizada."
+
+#: templates/base.html:5
+msgid "Wiki Board"
+msgstr "Tablón Wiki"
+
+#: templates/base.html:11
+msgid "Home"
+msgstr "Inicio"
+
+#: templates/base.html:12 templates/post_detail.html:7
+#: templates/tag_list.html:2 templates/tag_list.html:4
+msgid "Tags"
+msgstr "Etiquetas"
+
+#: templates/base.html:13 templates/search.html:2 templates/search.html:8
+msgid "Search"
+msgstr "Buscar"
+
+#: templates/base.html:14
+msgid "Citation Stats"
+msgstr "Estadísticas de citas"
+
+#: templates/base.html:17 templates/base.html:61 templates/notifications.html:2
+#: templates/notifications.html:4
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: templates/base.html:18
+msgid "New Post"
+msgstr "Nueva publicación"
+
+#: templates/base.html:20
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: templates/base.html:22 templates/login.html:2 templates/login.html:4
+#: templates/login.html:8
+msgid "Login"
+msgstr "Iniciar sesión"
+
+#: templates/base.html:23 templates/register.html:2 templates/register.html:4
+#: templates/register.html:8
+msgid "Register"
+msgstr "Registrarse"
+
+#: templates/base.html:49
+msgid "Continue"
+msgstr "Continuar"
+
+#: templates/base.html:50
+msgid "Close"
+msgstr "Cerrar"
+
+#: templates/citation_form.html:2
+#, python-format
+msgid "%(action)s Citation"
+msgstr ""
+
+#: templates/citation_form.html:4
+#, python-format
+msgid "%(action)s Citation for %(title)s"
+msgstr ""
+
+#: templates/citation_form.html:6 templates/post_detail.html:82
+msgid "Citation part (JSON)"
+msgstr "Parte de la cita (JSON)"
+
+#: templates/citation_form.html:7 templates/post_detail.html:83
+msgid "Citation text"
+msgstr "Texto de la cita"
+
+#: templates/citation_stats.html:2 templates/citation_stats.html:4
+msgid "Citation Statistics"
+msgstr "Estadísticas de citas"
+
+#: templates/citation_stats.html:7
+msgid "DOI / Citation"
+msgstr "DOI / Cita"
+
+#: templates/citation_stats.html:8
+msgid "Usage Count"
+msgstr "Número de usos"
+
+#: templates/citation_stats.html:9 templates/index.html:2
+msgid "Posts"
+msgstr "Publicaciones"
+
+#: templates/diff.html:2
+msgid "Diff"
+msgstr "Diferencia"
+
+#: templates/diff.html:4
+#, python-format
+msgid "Diff for %(title)s"
+msgstr "Diferencia para %(title)s"
+
+#: templates/diff.html:6
+msgid "Back to history"
+msgstr "Volver al historial"
+
+#: templates/history.html:2 templates/post_detail.html:114
+msgid "History"
+msgstr "Historial"
+
+#: templates/history.html:4
+#, python-format
+msgid "History for %(title)s"
+msgstr "Historial de %(title)s"
+
+#: templates/history.html:7 templates/index.html:7
+msgid "by"
+msgstr "por"
+
+#: templates/history.html:8
+msgid "diff"
+msgstr "diff"
+
+#: templates/index.html:4
+#, python-format
+msgid "Posts tagged \"%(tag)s\""
+msgstr "Publicaciones etiquetadas \"%(tag)s\""
+
+#: templates/index.html:4
+msgid "All Posts"
+msgstr "Todas las publicaciones"
+
+#: templates/index.html:9
+msgid "No posts yet."
+msgstr "No hay publicaciones."
+
+#: templates/login.html:6 templates/register.html:6
+msgid "Username"
+msgstr "Nombre de usuario"
+
+#: templates/login.html:7 templates/register.html:7
+msgid "Password"
+msgstr "Contraseña"
+
+#: templates/notifications.html:11
+msgid "No notifications."
+msgstr "Sin notificaciones."
+
+#: templates/post_detail.html:14
+msgid "Metadata"
+msgstr "Metadatos"
+
+#: templates/post_detail.html:16
+msgid "Common"
+msgstr "Común"
+
+#: templates/post_detail.html:24
+msgid "Your Metadata"
+msgstr "Tus metadatos"
+
+#: templates/post_detail.html:35
+msgid "Citations"
+msgstr "Citas"
+
+#: templates/post_detail.html:37
+msgid "Global"
+msgstr "Global"
+
+#: templates/post_detail.html:48 templates/post_detail.html:66
+msgid "Delete"
+msgstr "Eliminar"
+
+#: templates/post_detail.html:56
+msgid "Your Citations"
+msgstr "Tus citas"
+
+#: templates/post_detail.html:76 templates/post_detail.html:84
+msgid "Add Citation"
+msgstr "Agregar cita"
+
+#: templates/post_detail.html:79 templates/post_form.html:6
+msgid "Title"
+msgstr "Título"
+
+#: templates/post_detail.html:80
+msgid "Fetch Citation"
+msgstr "Obtener cita"
+
+#: templates/post_detail.html:107
+msgid "Other languages"
+msgstr "Otros idiomas"
+
+#: templates/post_detail.html:122
+msgid "Unwatch"
+msgstr "Dejar de seguir"
+
+#: templates/post_detail.html:126
+msgid "Watch"
+msgstr "Seguir"
+
+#: templates/post_form.html:2 templates/post_form.html:4
+#, python-format
+msgid "%(action)s Post"
+msgstr "Publicación %(action)s"
+
+#: templates/post_form.html:10
+msgid "Suggest Citation"
+msgstr "Sugerir cita"
+
+#: templates/post_form.html:13
+msgid "Path (e.g., docs/start)"
+msgstr "Ruta (ej., docs/start)"
+
+#: templates/post_form.html:14
+msgid "Language code"
+msgstr "Código de idioma"
+
+#: templates/post_form.html:15
+msgid "Comma separated tags"
+msgstr "Etiquetas separadas por comas"
+
+#: templates/post_form.html:16
+msgid "Post metadata (JSON)"
+msgstr "Metadatos de la publicación (JSON)"
+
+#: templates/post_form.html:17
+msgid "Your metadata (JSON)"
+msgstr "Tus metadatos (JSON)"
+
+#: templates/post_form.html:56
+msgid "Save"
+msgstr "Guardar"
+
+#: templates/search.html:4
+msgid "Search Posts"
+msgstr "Buscar publicaciones"
+
+#: templates/search.html:6
+msgid "Key"
+msgstr "Clave"
+
+#: templates/search.html:7
+msgid "Value"
+msgstr "Valor"
+
+#: templates/search.html:15
+msgid "No posts found."
+msgstr "No se encontraron publicaciones."
+
+#: templates/tag_list.html:9
+msgid "No tags yet."
+msgstr "Aún no hay etiquetas."
+


### PR DESCRIPTION
## Summary
- integrate Flask-Babel with English and Spanish locales
- wrap templates and route flashes with `_()` and add Spanish translations
- stop tracking compiled `.mo` files and ignore them going forward

## Testing
- `pip install -r requirements.txt`
- `pybabel extract -F babel.cfg -o messages.pot .`
- `pybabel compile -d translations`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a05d9822208329b13315211921a8a1