### PR TITLE
Add Table of Contents to posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -503,13 +503,16 @@ def post_detail(post_id: int):
             .all()
         )
     base = url_for('document', language=post.language, doc_path='')
-    html_body = markdown.markdown(
-        post.body, extensions=[WikiLinkExtension(base_url=base)]
+    md = markdown.Markdown(
+        extensions=[WikiLinkExtension(base_url=base), 'toc']
     )
+    html_body = md.convert(post.body)
+    toc = md.toc
     return render_template(
         'post_detail.html',
         post=post,
         html_body=html_body,
+        toc=toc,
         metadata=post_meta,
         user_metadata=user_meta,
         citations=citations,

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,16 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 10px; }
 textarea { width: 100%; }
+
+.post-layout { display: flex; }
+.toc-container {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-right: 20px;
+  background: #f9f9f9;
+  min-width: 200px;
+}
+.toc-container .toc { margin: 0; }
+.toc-container .toc ul { list-style: none; padding-left: 0; }
+.toc-container .toc a { text-decoration: none; }
+.post-body { flex: 1; }

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -3,7 +3,15 @@
 {% block content %}
 <h1>{{ post.title }} ({{ post.language }})</h1>
 <p><small>{{ post.path }}</small></p>
-<div>{{ html_body|safe }}</div>
+<div class="post-layout">
+  {% if toc %}
+  <nav class="toc-container">
+    <h2>{{ _('Contents') }}</h2>
+    {{ toc|safe }}
+  </nav>
+  {% endif %}
+  <div class="post-body">{{ html_body|safe }}</div>
+</div>
 <p>{{ _('Tags') }}:
   {% for tag in post.tags %}
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>


### PR DESCRIPTION
## Summary
- Generate Table of Contents when rendering posts using Markdown's `toc` extension.
- Pass TOC markup to the post detail template and render it alongside article content.
- Style the TOC and layout with new CSS classes.

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a062f657c88329ae56c3d6e7037234