### PR TITLE
Add requested post workflow

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,10 +12,12 @@
   <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a> |
   <a href="{{ url_for('search') }}">{{ _('Search') }}</a> |
   <a href="{{ url_for('citation_stats') }}">{{ _('Citation Stats') }}</a> |
+  <a href="{{ url_for('requested_posts') }}">{{ _('Requested Posts') }}</a> |
   {% if current_user.is_authenticated %}
     {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
     <a href="{{ url_for('notifications') }}">{{ _('Notifications') }}{% if unread %} ({{ unread }}){% endif %}</a> |
     <a href="{{ url_for('create_post') }}">{{ _('New Post') }}</a> |
+    <a href="{{ url_for('request_post') }}">{{ _('Request Post') }}</a> |
     <span>{{ current_user.username }}</span> |
     <a href="{{ url_for('logout') }}">{{ _('Logout') }}</a>
   {% else %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -3,8 +3,8 @@
 {% block content %}
 <h1>{{ _('%(action)s Post', action=action) }}</h1>
 <form method="post">
-  <p><input name="title" placeholder="{{ _('Title') }}" value="{{ post.title if post else '' }}"></p>
-  <p><textarea name="body" rows="10" cols="50">{{ post.body if post else '' }}</textarea></p>
+  <p><input name="title" placeholder="{{ _('Title') }}" value="{{ post.title if post else prefill_title or '' }}"></p>
+  <p><textarea name="body" rows="10" cols="50">{{ post.body if post else prefill_body or '' }}</textarea></p>
   <div id="preview"></div>
   {% if post %}
   <p><button type="button" id="suggest-citations">{{ _('Suggest Citation') }}</button></p>
@@ -15,6 +15,7 @@
   <p><input name="tags" placeholder="{{ _('Comma separated tags') }}" value="{{ tags if tags else '' }}"></p>
   <p><textarea name="metadata" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea></p>
   <p><textarea name="user_metadata" placeholder="{{ _('Your metadata (JSON)') }}" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
+  {% if request_id %}<input type="hidden" name="request_id" value="{{ request_id }}">{% endif %}
   <p><button type="submit">{{ action }}</button></p>
 </form>
 <script>

--- a/templates/request_form.html
+++ b/templates/request_form.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Request Post') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Request Post') }}</h1>
+<form method="post">
+  <p><input name="title" placeholder="{{ _('Title') }}"></p>
+  <p><textarea name="description" rows="5" cols="50" placeholder="{{ _('Description') }}"></textarea></p>
+  <p><button type="submit">{{ _('Submit') }}</button></p>
+</form>
+{% endblock %}

--- a/templates/requested_posts.html
+++ b/templates/requested_posts.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Requested Posts') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Requested Posts') }}</h1>
+<ul>
+  {% for req in requests %}
+    <li>
+      <strong>{{ req.title }}</strong> - {{ req.description }} ({{ req.requester.username }})
+      {% if current_user.is_authenticated %}
+      <a href="{{ url_for('create_post', request_id=req.id) }}">{{ _('Convert to Post') }}</a>
+      {% endif %}
+    </li>
+  {% else %}
+    <li>{{ _('No requests yet.') }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `RequestedPost` model for storing post ideas from users
- allow users to submit requests and browse pending requests
- enable converting a request into a full post, clearing it from the pending list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log ; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a06519e28083298810768516bd9240