### PR TITLE
Add user profile pages and link usernames

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
     <a href="{{ url_for('notifications') }}">{{ _('Notifications') }}{% if unread %} ({{ unread }}){% endif %}</a> |
     <a href="{{ url_for('create_post') }}">{{ _('New Post') }}</a> |
     <a href="{{ url_for('request_post') }}">{{ _('Request Post') }}</a> |
-    <span>{{ current_user.username }}</span> |
+      <a href="{{ url_for('profile', username=current_user.username) }}">{{ current_user.username }}</a> |
     <a href="{{ url_for('logout') }}">{{ _('Logout') }}</a>
   {% else %}
     <a href="{{ url_for('login') }}">{{ _('Login') }}</a> |

--- a/templates/history.html
+++ b/templates/history.html
@@ -4,7 +4,7 @@
 <h1>{{ _('History for %(title)s', title=post.title) }}</h1>
 <ul>
   {% for rev in revisions %}
-    <li>{{ rev.created_at }} {{ _('by') }} {{ rev.user.username }} -
+      <li>{{ rev.created_at }} {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a> -
       <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">{{ _('diff') }}</a>
     </li>
   {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 <h1>{% if tag %}{{ _('Posts tagged "%(tag)s"', tag=tag.name) }}{% else %}{{ _('All Posts') }}{% endif %}</h1>
 <ul id="post-list">
   {% for post in posts %}
-    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}) {{ _('by') }} {{ post.author.username }}</li>
+      <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}) {{ _('by') }} <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username }}</a></li>
   {% else %}
     <li>{{ _('No posts yet.') }}</li>
   {% endfor %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -48,7 +48,7 @@
       <li>
         <strong>{{ c.citation_part|format_metadata }}:</strong>
         {{ c.citation_text }}
-        &mdash; {{ c.user.username }},
+        &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
           <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">{{ _('Edit') }}</a>
@@ -67,7 +67,7 @@
       <li>
         <strong>{{ c.citation_part|format_metadata }}:</strong>
         {{ c.citation_text }}
-        &mdash; {{ c.user.username }},
+        &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}">{{ _('Edit') }}</a>
         <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" style="display:inline">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}{{ user.username }}{% endblock %}
+{% block content %}
+<h1>{{ user.username }}</h1>
+{% if user.avatar_url %}
+  <img src="{{ user.avatar_url }}" alt="{{ user.username }} avatar" style="max-width:150px;">
+{% endif %}
+<p>{{ user.bio }}</p>
+<section>
+  <h2>{{ _('Contribution Metrics') }}</h2>
+  <ul>
+    <li>{{ _('Posts') }}: {{ post_count }}</li>
+    <li>{{ _('Citations') }}: {{ citation_count }}</li>
+  </ul>
+</section>
+<section>
+  <h2>{{ _('Recent Posts') }}</h2>
+  <ul>
+  {% for p in posts %}
+    <li><a href="{{ url_for('document', language=p.language, doc_path=p.path) }}">{{ p.title }}</a></li>
+  {% else %}
+    <li>{{ _('No posts yet.') }}</li>
+  {% endfor %}
+  </ul>
+</section>
+{% if current_user.is_authenticated and current_user.id == user.id %}
+<section>
+  <h2>{{ _('Edit Profile') }}</h2>
+  <form method="post">
+    <p><input type="text" name="avatar_url" placeholder="{{ _('Avatar URL') }}" value="{{ user.avatar_url or '' }}"></p>
+    <p><textarea name="bio" placeholder="{{ _('Bio') }}" rows="4" cols="50">{{ user.bio or '' }}</textarea></p>
+    <p><button type="submit">{{ _('Update') }}</button></p>
+  </form>
+</section>
+{% endif %}
+{% endblock %}

--- a/templates/requested_posts.html
+++ b/templates/requested_posts.html
@@ -5,7 +5,7 @@
 <ul>
   {% for req in requests %}
     <li>
-      <strong>{{ req.title }}</strong> - {{ req.description }} ({{ req.requester.username }})
+        <strong>{{ req.title }}</strong> - {{ req.description }} (<a href="{{ url_for('profile', username=req.requester.username) }}">{{ req.requester.username }}</a>)
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('create_post', request_id=req.id) }}">{{ _('Convert to Post') }}</a>
       {% endif %}


### PR DESCRIPTION
## Summary
- add `avatar_url` and `bio` fields to users and implement `/user/<username>` profile route
- new profile page shows avatar, bio, recent posts, and contribution stats with self-edit form
- link usernames around the site to their profile pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a066494fd48329875fcddaa0a981c7