### PR TITLE
Display post location on map

### DIFF
--- a/app.py
+++ b/app.py
@@ -562,6 +562,33 @@ def create_post():
 def post_detail(post_id: int):
     post = Post.query.get_or_404(post_id)
     post_meta = {m.key: m.value for m in post.metadata}
+    location = None
+    for value in post_meta.values():
+        if isinstance(value, dict):
+            lat = value.get('lat') or value.get('latitude')
+            lon = value.get('lon') or value.get('lng') or value.get('longitude')
+            if lat is not None and lon is not None:
+                try:
+                    location = {'lat': float(lat), 'lon': float(lon)}
+                except (TypeError, ValueError):
+                    location = None
+                if location:
+                    break
+    if location is None:
+        lat = (
+            post_meta.get('lat')
+            or post_meta.get('latitude')
+        )
+        lon = (
+            post_meta.get('lon')
+            or post_meta.get('lng')
+            or post_meta.get('longitude')
+        )
+        if lat is not None and lon is not None:
+            try:
+                location = {'lat': float(lat), 'lon': float(lon)}
+            except (TypeError, ValueError):
+                location = None
     user_meta = {}
     citations = (
         PostCitation.query.filter_by(post_id=post.id)
@@ -593,6 +620,7 @@ def post_detail(post_id: int):
         html_body=html_body,
         toc=toc,
         metadata=post_meta,
+        location=location,
         user_metadata=user_meta,
         citations=citations,
         user_citations=user_citations,

--- a/static/style.css
+++ b/static/style.css
@@ -14,3 +14,16 @@ textarea { width: 100%; }
 .toc-container .toc ul { list-style: none; padding-left: 0; }
 .toc-container .toc a { text-decoration: none; }
 .post-body { flex: 1; }
+
+#map {
+  height: 400px;
+  width: 100%;
+  max-width: 600px;
+  margin: 1em 0;
+}
+
+@media (max-width: 600px) {
+  #map {
+    height: 300px;
+  }
+}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -27,6 +27,9 @@
       <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
     {% endfor %}
   </ul>
+  {% if location %}
+  <div id="map"></div>
+  {% endif %}
   {% endif %}
   {% if user_metadata %}
   <h3>{{ _('Your Metadata') }}</h3>
@@ -136,4 +139,17 @@
     {% endif %}
   {% endif %}
 </p>
+{% if location %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script>
+  const loc = {{ location|tojson }};
+  const map = L.map('map').setView([loc.lat, loc.lon], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+  L.marker([loc.lat, loc.lon]).addTo(map);
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Extract latitude and longitude from post metadata and pass to templates
- Render a Leaflet map with a marker for the post location
- Add responsive styling for the map container

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0687feafc8329bc05353470e18205