### PR TITLE
Refactor Babel locale selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,11 @@ cr = Crossref()
 babel = Babel(app)
 
 
-@babel.localeselector
-def get_locale():
+def select_locale():
     return request.accept_languages.best_match(app.config['LANGUAGES'])
+
+
+babel.locale_selector_func = select_locale
 
 
 def fetch_bibtex_by_title(title: str) -> str | None:


### PR DESCRIPTION
## Summary
- replace deprecated `@babel.localeselector` with standalone `select_locale` and assign via `babel.locale_selector_func`

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06a7062e88329ae09ea7a8145e882