### PR TITLE
Add post deletion with author/admin permissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -660,6 +660,19 @@ def unwatch_post(post_id: int):
     return redirect(url_for('post_detail', post_id=post.id))
 
 
+@app.route('/post/<int:post_id>/delete', methods=['POST'])
+@login_required
+def delete_post(post_id: int):
+    post = Post.query.get_or_404(post_id)
+    if post.author_id != current_user.id and not current_user.is_admin():
+        flash(_('Permission denied.'))
+        return redirect(url_for('post_detail', post_id=post.id))
+    db.session.delete(post)
+    db.session.commit()
+    flash(_('Post deleted.'))
+    return redirect(url_for('index'))
+
+
 @app.route('/docs/<string:language>/<path:doc_path>')
 def document(language: str, doc_path: str):
     post = Post.query.filter_by(language=language, path=doc_path).first_or_404()

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -125,6 +125,9 @@
   <a href="{{ url_for('history', post_id=post.id) }}">{{ _('History') }}</a>
   {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
     | <a href="{{ url_for('edit_post', post_id=post.id) }}">{{ _('Edit') }}</a>
+    | <form action="{{ url_for('delete_post', post_id=post.id) }}" method="post" style="display:inline">
+        <button type="submit">{{ _('Delete') }}</button>
+      </form>
   {% endif %}
   {% if current_user.is_authenticated %}
     {% set watching = post.watchers | selectattr('user_id', 'equalto', current_user.id) | list | length > 0 %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -18,6 +18,11 @@
   {% if request_id %}<input type="hidden" name="request_id" value="{{ request_id }}">{% endif %}
   <p><button type="submit">{{ action }}</button></p>
 </form>
+{% if post and current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
+<form action="{{ url_for('delete_post', post_id=post.id) }}" method="post" style="margin-top:1em">
+  <button type="submit">{{ _('Delete') }}</button>
+</form>
+{% endif %}
 <script>
 const bodyInput = document.querySelector('textarea[name="body"]');
 const previewEl = document.getElementById('preview');


### PR DESCRIPTION
## Summary
- add `/post/<int:post_id>/delete` route with author/admin permission check and flash message
- expose delete controls in post detail and edit views when authorized

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06daa12d8832999490cc6b561d0a7