### PR TITLE
Add admin posts management route

### DIFF
--- a/templates/admin/posts.html
+++ b/templates/admin/posts.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Manage Posts') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Manage Posts') }}</h1>
+<form method="get" class="mb-3">
+  <input type="text" name="q" value="{{ q }}" placeholder="{{ _('Search') }}">
+  <button type="submit" class="btn btn-primary btn-sm">{{ _('Search') }}</button>
+</form>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>{{ _('ID') }}</th>
+      <th>{{ _('Title') }}</th>
+      <th>{{ _('Path') }}</th>
+      <th>{{ _('Language') }}</th>
+      <th>{{ _('Actions') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for post in pagination.items %}
+    <tr>
+      <td>{{ post.id }}</td>
+      <td><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a></td>
+      <td>{{ post.path }}</td>
+      <td>{{ post.language }}</td>
+      <td>
+        <a href="{{ url_for('edit_post', post_id=post.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
+        <form action="{{ url_for('delete_post', post_id=post.id) }}" method="post" style="display:inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
+          <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<nav>
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('admin_posts', page=pagination.prev_num, q=q) }}">&laquo;</a>
+    </li>
+    {% for p in range(1, pagination.pages + 1) %}
+    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('admin_posts', page=p, q=q) }}">{{ p }}</a></li>
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('admin_posts', page=pagination.next_num, q=q) }}">&raquo;</a>
+    </li>
+  </ul>
+</nav>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,9 @@
   <a href="{{ url_for('citation_stats') }}">{{ _('Citation Stats') }}</a> |
   <a href="{{ url_for('requested_posts') }}">{{ _('Requested Posts') }}</a> |
   {% if current_user.is_authenticated %}
+    {% if current_user.is_admin() %}
+      <a href="{{ url_for('admin_posts') }}">{{ _('Manage Posts') }}</a> |
+    {% endif %}
     {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
     <a href="{{ url_for('notifications') }}">{{ _('Notifications') }}{% if unread %} ({{ unread }}){% endif %}</a> |
     <a href="{{ url_for('create_post') }}">{{ _('New Post') }}</a> |


### PR DESCRIPTION
## Summary
- Add `/admin/posts` route for admins to search, paginate, edit, and delete posts
- Introduce admin posts management template
- Display admin navigation link only for admin users

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06e8bbcf0832989cf68df6cbcdefe