### PR TITLE
Load configuration from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 *.pyc
 *.db
+*.mo
+
+# Instance and local configuration
 instance/
 .env
-*.mo

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ pip install -r requirements.txt
 The application uses the Crossref API through the `habanero` library, so network
 access is required when querying Crossref.
 
+## Configuration
+Create a `.env` file in the project root to configure runtime settings. The
+following variables are supported:
+
+- `SECRET_KEY` – Flask secret key used for session signing.
+- `SQLALCHEMY_DATABASE_URI` – database connection string.
+- `BABEL_DEFAULT_LOCALE` – default locale for translations.
+- `LANGUAGES` – comma-separated list of supported languages.
+- `BABEL_TRANSLATION_DIRECTORIES` – path to translation files.
+
+Example `.env`:
+
+```ini
+SECRET_KEY=dev-secret
+SQLALCHEMY_DATABASE_URI=sqlite:///wiki.db
+BABEL_DEFAULT_LOCALE=en
+LANGUAGES=en,es
+BABEL_TRANSLATION_DIRECTORIES=translations
+```
+
 ## Usage
 ```bash
 python app.py

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import difflib
 import json
+import os
 import re
 import markdown
 from datetime import datetime
@@ -20,15 +21,24 @@ from habanero import Crossref
 import bibtexparser
 from sqlalchemy import func, event, or_
 from flask_babel import Babel, _
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'dev-secret'
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///wiki.db'
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'dev-secret')
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
+    'SQLALCHEMY_DATABASE_URI', 'sqlite:///wiki.db'
+)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['BABEL_DEFAULT_LOCALE'] = 'en'
-app.config['BABEL_DEFAULT_TIMEZONE'] = 'UTC'
-app.config['LANGUAGES'] = ['en', 'es']
-app.config['BABEL_TRANSLATION_DIRECTORIES'] = 'translations'
+app.config['BABEL_DEFAULT_LOCALE'] = os.getenv('BABEL_DEFAULT_LOCALE', 'en')
+app.config['BABEL_DEFAULT_TIMEZONE'] = os.getenv('BABEL_DEFAULT_TIMEZONE', 'UTC')
+app.config['LANGUAGES'] = [
+    lang.strip() for lang in os.getenv('LANGUAGES', 'en,es').split(',')
+]
+app.config['BABEL_TRANSLATION_DIRECTORIES'] = os.getenv(
+    'BABEL_TRANSLATION_DIRECTORIES', 'translations'
+)
 
 db = SQLAlchemy(app)
 login_manager = LoginManager(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bibtexparser>=1.4.0
 
 flask-socketio>=5.3.6
 Flask-Babel>=3.1.0
+python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
- load environment variables from `.env` using python-dotenv
- replace hard-coded configuration in `app.py` with `os.getenv` defaults
- document required environment variables and keep `.env` ignored

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a071d998e883299713e761f4a648f1