### PR TITLE
Support GeoJSON metadata and render multiple map features

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -27,7 +27,7 @@
       <li><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
     {% endfor %}
   </ul>
-  {% if location %}
+  {% if geodata %}
   <div id="map"></div>
   {% endif %}
   {% endif %}
@@ -142,17 +142,26 @@
     {% endif %}
   {% endif %}
 </p>
-{% if location %}
+{% if geodata %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script>
-  const loc = {{ location|tojson }};
-  const map = L.map('map').setView([loc.lat, loc.lon], 13);
+  const data = { type: 'FeatureCollection', features: {{ geodata|tojson }} };
+  const map = L.map('map').setView([0, 0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors'
   }).addTo(map);
-  L.marker([loc.lat, loc.lon]).addTo(map);
+  const layer = L.geoJSON(data).addTo(map);
+  try {
+    map.fitBounds(layer.getBounds());
+  } catch (e) {
+    // If only a single point, getBounds may return empty; fallback
+    if (data.features.length > 0) {
+      const c = data.features[0].geometry.coordinates;
+      map.setView([c[1], c[0]], 13);
+    }
+  }
 </script>
 {% endif %}
 {% endblock %}

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -4,7 +4,12 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app import format_metadata_value, extract_location, COORD_OUT_OF_RANGE_MSG
+from app import (
+    format_metadata_value,
+    extract_location,
+    extract_geodata,
+    COORD_OUT_OF_RANGE_MSG,
+)
 
 
 def test_format_metadata_value_valid():
@@ -20,6 +25,18 @@ def test_format_metadata_value_invalid():
     assert COORD_OUT_OF_RANGE_MSG in str(result)
 
 
+def test_format_metadata_value_geojson_string():
+    value = '{"type":"Point","coordinates":[20,10]}'
+    result = format_metadata_value(value)
+    assert '#map' in result
+
+
+def test_format_metadata_value_list_points():
+    value = [{'lat': 10, 'lon': 20}, {'lat': 30, 'lon': 40}]
+    result = format_metadata_value(value)
+    assert '#map' in result
+
+
 def test_extract_location_valid():
     meta = {'location': {'lat': '45', 'lon': '-75'}}
     loc, warning = extract_location(meta)
@@ -32,3 +49,10 @@ def test_extract_location_invalid():
     loc, warning = extract_location(meta)
     assert loc is None
     assert warning == COORD_OUT_OF_RANGE_MSG
+
+
+def test_extract_geodata_from_list():
+    meta = {'points': [{'lat': 10, 'lon': 20}, {'lat': 30, 'lon': 40}]}
+    geoms = extract_geodata(meta)
+    assert len(geoms) == 2
+    assert all(g['geometry']['type'] == 'Point' for g in geoms)


### PR DESCRIPTION
## Summary
- detect geodata from lists and GeoJSON strings
- display Leaflet map with multiple markers or polygons on post pages
- format metadata with map links for geodata values and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a078abc55083299cc453993e81cf9f