### PR TITLE
Add geospatial search and coordinate fields to posts

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -11,8 +11,11 @@
       {% endfor %}
     </select>
   </label>
-  <label>{{ _('Value') }}: <input type="text" name="value" value="{{ value }}"></label>
-  <button type="submit">{{ _('Search') }}</button>
+    <label>{{ _('Value') }}: <input type="text" name="value" value="{{ value }}"></label>
+    <label>{{ _('Latitude') }}: <input type="text" name="lat" value="{{ lat if lat is not none else '' }}"></label>
+    <label>{{ _('Longitude') }}: <input type="text" name="lon" value="{{ lon if lon is not none else '' }}"></label>
+    <label>{{ _('Radius (km)') }}: <input type="text" name="radius" value="{{ radius if radius is not none else '' }}"></label>
+    <button type="submit">{{ _('Search') }}</button>
 </form>
 {% if posts is not none %}
 <ul>
@@ -21,8 +24,11 @@
   {% else %}
     <li>{{ _('No posts found.') }}</li>
   {% endfor %}
-</ul>
-{% else %}
+  </ul>
+  <script>
+    const postCoords = {{ coords_json|safe }};
+  </script>
+  {% else %}
   <p>{{ _('Select a key and enter a value. You can also choose "title" or "path" to search by post fields.') }}</p>
   {% if examples %}
   <p>{{ _('Example posts:') }}</p>

--- a/tests/test_search_location.py
+++ b/tests/test_search_location.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+import pytest
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        near = Post(
+            title='Near Post',
+            body='body',
+            path='near',
+            language='en',
+            author_id=user.id,
+            latitude=10.0,
+            longitude=10.0,
+        )
+        far = Post(
+            title='Far Post',
+            body='body',
+            path='far',
+            language='en',
+            author_id=user.id,
+            latitude=20.0,
+            longitude=20.0,
+        )
+        db.session.add_all([near, far])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_search_filters_by_distance(client):
+    resp = client.get('/search', query_string={'lat': 10, 'lon': 10, 'radius': 500})
+    data = resp.get_data(as_text=True)
+    assert 'Near Post' in data
+    assert 'Far Post' not in data
+    assert 'postCoords' in data
+    assert '"lat": 10.0' in data
+    assert '"lat": 20.0' not in data
+


### PR DESCRIPTION
## Summary
- store latitude and longitude on posts
- filter search results by distance using `lat`, `lon`, and `radius` parameters
- expose search result coordinates to the template for map visualisation
- add tests for geospatial search filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07bf2f7308329a5b2bd516f1a215a