### PR TITLE
Add map-based coordinate capture for posts

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block title %}{{ _('%(action)s Post', action=action) }}{% endblock %}
 {% block content %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
 <h1>{{ _('%(action)s Post', action=action) }}</h1>
 <form method="post">
   <p><input name="title" placeholder="{{ _('Title') }}" value="{{ post.title if post else prefill_title or '' }}"></p>
@@ -17,8 +19,9 @@
     <input id="address-input" placeholder="{{ _('Address') }}">
     <button type="button" id="find-coordinates">{{ _('Find Coordinates') }}</button>
   </p>
-  <input type="hidden" name="lat" id="lat">
-  <input type="hidden" name="lon" id="lon">
+  <div id="map" style="height:300px"></div>
+  <input type="hidden" name="lat" id="lat" value="{{ lat or '' }}">
+  <input type="hidden" name="lon" id="lon" value="{{ lon or '' }}">
   <p id="geocode-error" style="color:red"></p>
   <p><textarea name="metadata" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea></p>
   <p><textarea name="user_metadata" placeholder="{{ _('Your metadata (JSON)') }}" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea></p>
@@ -30,6 +33,8 @@
   <button type="submit">{{ _('Delete') }}</button>
 </form>
 {% endif %}
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
 <script>
 const bodyInput = document.querySelector('textarea[name="body"]');
 const previewEl = document.getElementById('preview');
@@ -45,6 +50,36 @@ function updatePreview() {
 bodyInput.addEventListener('input', updatePreview);
 updatePreview();
 
+const map = L.map('map').setView([0, 0], 2);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+const drawnItems = new L.FeatureGroup();
+map.addLayer(drawnItems);
+const drawControl = new L.Control.Draw({
+  edit: { featureGroup: drawnItems },
+  draw: { polygon:false, polyline:false, rectangle:false, circle:false, circlemarker:false }
+});
+map.addControl(drawControl);
+
+const latField = document.getElementById('lat');
+const lonField = document.getElementById('lon');
+const initLat = parseFloat(latField.value);
+const initLon = parseFloat(lonField.value);
+if (!isNaN(initLat) && !isNaN(initLon)) {
+  L.marker([initLat, initLon]).addTo(drawnItems);
+  map.setView([initLat, initLon], 13);
+}
+
+map.on(L.Draw.Event.CREATED, function (e) {
+  drawnItems.clearLayers();
+  const layer = e.layer;
+  drawnItems.addLayer(layer);
+  const latlng = layer.getLatLng();
+  latField.value = latlng.lat;
+  lonField.value = latlng.lng;
+});
+
 document.getElementById('find-coordinates').addEventListener('click', function () {
   const addr = document.getElementById('address-input').value;
   fetch('{{ url_for('geocode') }}?address=' + encodeURIComponent(addr))
@@ -54,8 +89,11 @@ document.getElementById('find-coordinates').addEventListener('click', function (
         document.getElementById('geocode-error').textContent = data.error;
       } else {
         document.getElementById('geocode-error').textContent = '';
-        document.getElementById('lat').value = data.lat;
-        document.getElementById('lon').value = data.lon;
+        latField.value = data.lat;
+        lonField.value = data.lon;
+        drawnItems.clearLayers();
+        L.marker([data.lat, data.lon]).addTo(drawnItems);
+        map.setView([data.lat, data.lon], 13);
       }
     })
     .catch(() => {


### PR DESCRIPTION
## Summary
- Integrate Leaflet and Leaflet.draw in post form for interactive mapping
- Capture marker coordinates into hidden form fields
- Serialize coordinates into PostMetadata on post create/edit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07db84c848329971237996dfa3e5f