### PR TITLE
Add full-text search and tag filters

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -3,6 +3,8 @@
 {% block content %}
 <h1>{{ _('Search Posts') }}</h1>
 <form method="get">
+  <label>{{ _('Query') }}: <input type="text" name="q" value="{{ q }}"></label>
+  <label>{{ _('Tags (comma separated)') }}: <input type="text" name="tags" value="{{ tags }}"></label>
   <label>{{ _('Key') }}:
     <select name="key">
       <option value="">--</option>
@@ -11,20 +13,23 @@
       {% endfor %}
     </select>
   </label>
-    <label>{{ _('Value') }}: <input type="text" name="value" value="{{ value }}"></label>
-    <label>{{ _('Latitude') }}: <input type="text" name="lat" value="{{ lat if lat is not none else '' }}"></label>
-    <label>{{ _('Longitude') }}: <input type="text" name="lon" value="{{ lon if lon is not none else '' }}"></label>
-    <label>{{ _('Radius (km)') }}: <input type="text" name="radius" value="{{ radius if radius is not none else '' }}"></label>
-    <button type="submit">{{ _('Search') }}</button>
+  <label>{{ _('Value') }}: <input type="text" name="value" value="{{ value }}"></label>
+  <label>{{ _('Latitude') }}: <input type="text" name="lat" value="{{ lat if lat is not none else '' }}"></label>
+  <label>{{ _('Longitude') }}: <input type="text" name="lon" value="{{ lon if lon is not none else '' }}"></label>
+  <label>{{ _('Radius (km)') }}: <input type="text" name="radius" value="{{ radius if radius is not none else '' }}"></label>
+  <button type="submit">{{ _('Search') }}</button>
 </form>
+{% if all_tags %}
+<p>{{ _('Available tags:') }} {{ all_tags|join(', ') }}</p>
+{% endif %}
 {% if posts is not none %}
 <ul>
   {% for post in posts %}
-    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }})</li>
+    <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}){% if post.tags %} - {{ post.tags|map(attribute='name')|join(', ') }}{% endif %}</li>
   {% else %}
     <li>{{ _('No posts found.') }}</li>
   {% endfor %}
-  </ul>
+</ul>
   <script>
     const postCoords = {{ coords_json|safe }};
   </script>

--- a/tests/test_search_fts.py
+++ b/tests/test_search_fts.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Tag
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        t1 = Tag(name='news')
+        t2 = Tag(name='science')
+        db.session.add_all([user, t1, t2])
+        db.session.commit()
+        p1 = Post(title='Apple', body='apple banana', path='p1', language='en', author_id=user.id)
+        p1.tags.append(t1)
+        p2 = Post(title='Banana', body='banana carrot', path='p2', language='en', author_id=user.id)
+        p2.tags.append(t2)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_fulltext_search(client):
+    resp = client.get('/search', query_string={'q': 'apple'})
+    text = resp.get_data(as_text=True)
+    assert 'Apple' in text
+    assert 'Banana' not in text
+
+
+def test_tag_filter(client):
+    resp = client.get('/search', query_string={'q': 'banana', 'tags': 'news'})
+    text = resp.get_data(as_text=True)
+    assert 'Apple' in text
+    assert 'Banana' not in text


### PR DESCRIPTION
## Summary
- Index posts with SQLite FTS5 and triggers for automatic updates
- Extend `/search` to query the FTS index and filter by tags
- Expose query and tag options in the search template and display matched tags
- Cover search and tag filtering with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0806064688329ba5d41483befb2c0