### PR TITLE
Add ability to revert posts to previous revisions

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -6,6 +6,11 @@
   {% for rev in revisions %}
       <li>{{ rev.created_at }} {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a> -
       <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">{{ _('diff') }}</a>
+      {% if current_user.is_authenticated and current_user.can_edit_posts() %}
+        - <form action="{{ url_for('revert_revision', post_id=post.id, rev_id=rev.id) }}" method="post" style="display:inline">
+            <button type="submit">{{ _('Revert') }}</button>
+          </form>
+      {% endif %}
     </li>
   {% endfor %}
 </ul>

--- a/tests/test_revert_revision.py
+++ b/tests/test_revert_revision.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        post = Post(title='Original Title', body='Original Body', path='p1', language='en', author_id=user.id)
+        db.session.add(post)
+        db.session.commit()
+        rev = Revision(post=post, user=user, title=post.title, body=post.body, path=post.path, language=post.language)
+        db.session.add(rev)
+        db.session.commit()
+        post.title = 'Edited Title'
+        post.body = 'Edited Body'
+        post.path = 'p2'
+        post.language = 'es'
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_revert_revision(client):
+    with app.app_context():
+        post = Post.query.first()
+        rev = Revision.query.filter_by(post_id=post.id).first()
+        post_id = post.id
+        rev_id = rev.id
+    resp = client.post(f'/post/{post_id}/revert/{rev_id}')
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.get(post_id)
+        assert post.title == 'Original Title'
+        assert post.body == 'Original Body'
+        assert post.path == 'p1'
+        assert post.language == 'en'
+        revisions = Revision.query.filter_by(post_id=post_id).order_by(Revision.id).all()
+        assert len(revisions) == 2
+        assert revisions[-1].title == 'Edited Title'


### PR DESCRIPTION
## Summary
- Implement `revert_revision` route that rolls back a post to a selected revision while preserving the current state
- Add "Revert" action to each revision in history view
- Cover revision rollback with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a081d0f6b4832987642f725a18864f