### PR TITLE
Add recent changes page

### DIFF
--- a/app.py
+++ b/app.py
@@ -619,6 +619,14 @@ def index():
     return render_template('index.html', posts=posts)
 
 
+@app.route('/recent')
+def recent_changes():
+    revisions = (
+        Revision.query.order_by(Revision.created_at.desc()).limit(20).all()
+    )
+    return render_template('recent.html', revisions=revisions)
+
+
 @app.route('/register', methods=['GET', 'POST'])
 def register():
     if request.method == 'POST':

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
   <a href="{{ url_for('index') }}">{{ _('Home') }}</a> |
   <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a> |
   <a href="{{ url_for('search') }}">{{ _('Search') }}</a> |
+  <a href="{{ url_for('recent_changes') }}">{{ _('Recent changes') }}</a> |
   <a href="{{ url_for('citation_stats') }}">{{ _('Citation Stats') }}</a> |
   <a href="{{ url_for('requested_posts') }}">{{ _('Requested Posts') }}</a> |
   {% if current_user.is_authenticated %}

--- a/templates/recent.html
+++ b/templates/recent.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Recent changes') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Recent changes') }}</h1>
+<ul>
+  {% for rev in revisions %}
+    <li>{{ rev.created_at }} - <a href="{{ url_for('document', language=rev.language, doc_path=rev.path) }}">{{ rev.title }}</a> {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a></li>
+  {% else %}
+    <li>{{ _('No revisions yet.') }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/recent` route listing latest revisions with associated posts and authors
- create template to display recent revisions
- link "Recent changes" in navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a082e4f808832991781155f35559a6