### PR TITLE
Add post backlinks tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,6 +348,20 @@ def extract_geodata(meta: dict) -> list[dict]:
     return geoms
 
 
+LINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
+
+
+def update_post_links(post: "Post") -> None:
+    """Update outgoing link records for ``post`` based on its body."""
+    PostLink.query.filter_by(source_id=post.id).delete()
+    targets = LINK_RE.findall(post.body or "")
+    for target in targets:
+        target = target.strip()
+        target_post = Post.query.filter_by(path=target, language=post.language).first()
+        if target_post and target_post.id != post.id:
+            db.session.add(PostLink(source_id=post.id, target_id=target_post.id))
+
+
 class WikiLinkInlineProcessor(InlineProcessor):
     def __init__(self, pattern, base_url):
         super().__init__(pattern)
@@ -459,6 +473,19 @@ class PostTag(db.Model):
     __tablename__ = 'post_tag'
     post_id = db.Column(db.Integer, db.ForeignKey('post.id'), primary_key=True)
     tag_id = db.Column(db.Integer, db.ForeignKey('tag.id'), primary_key=True)
+
+
+class PostLink(db.Model):
+    __tablename__ = 'post_link'
+    source_id = db.Column(db.Integer, db.ForeignKey('post.id'), primary_key=True)
+    target_id = db.Column(db.Integer, db.ForeignKey('post.id'), primary_key=True)
+
+    source = db.relationship(
+        'Post', foreign_keys=[source_id], backref='outgoing_links'
+    )
+    target = db.relationship(
+        'Post', foreign_keys=[target_id], backref='incoming_links'
+    )
 
 
 class PostWatch(db.Model):
@@ -784,6 +811,8 @@ def create_post():
                     UserPostMetadata(post=post, user=current_user, key=key, value=value)
                 )
 
+        update_post_links(post)
+
         rev = Revision(post=post, user=current_user, title=title, body=body,
                        path=path, language=language)
         db.session.add(rev)
@@ -854,6 +883,19 @@ def post_detail(post_id: int):
         citations=citations,
         user_citations=user_citations,
     )
+
+
+@app.route('/post/<int:post_id>/backlinks')
+def post_backlinks(post_id: int):
+    post = Post.query.get_or_404(post_id)
+    backlinks = (
+        PostLink.query.filter_by(target_id=post.id)
+        .join(Post, PostLink.source_id == Post.id)
+        .with_entities(Post)
+        .order_by(Post.title)
+        .all()
+    )
+    return render_template('backlinks.html', post=post, backlinks=backlinks)
 
 
 @app.route('/post/<int:post_id>/watch', methods=['POST'])
@@ -1181,6 +1223,7 @@ def edit_post(post_id: int):
                 )
         else:
             UserPostMetadata.query.filter_by(post_id=post.id, user_id=current_user.id).delete()
+        update_post_links(post)
         watchers = PostWatch.query.filter_by(post_id=post.id).all()
         for w in watchers:
             if w.user_id != current_user.id:

--- a/templates/backlinks.html
+++ b/templates/backlinks.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Backlinks for {{ post.title }}{% endblock %}
+{% block content %}
+<h1>{{ _('Backlinks for "%(title)s"', title=post.title) }}</h1>
+<ul>
+  {% for p in backlinks %}
+    <li><a href="{{ url_for('post_detail', post_id=p.id) }}">{{ p.title }}</a></li>
+  {% else %}
+    <li>{{ _('No backlinks') }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -123,6 +123,7 @@
 {% endif %}
 <p>
   <a href="{{ url_for('history', post_id=post.id) }}">{{ _('History') }}</a>
+  | <a href="{{ url_for('post_backlinks', post_id=post.id) }}">{{ _('Backlinks') }}</a>
   {% if current_user.is_authenticated and (current_user.id == post.author_id or current_user.is_admin()) %}
     | <a href="{{ url_for('edit_post', post_id=post.id) }}">{{ _('Edit') }}</a>
     | <form action="{{ url_for('delete_post', post_id=post.id) }}" method="post" style="display:inline">

--- a/tests/test_backlinks.py
+++ b/tests/test_backlinks.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostLink, update_post_links
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        p1 = Post(title='P1', body='See [[p2]]', path='p1', language='en', author=user)
+        p2 = Post(title='P2', body='No links', path='p2', language='en', author=user)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+        update_post_links(p1)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_backlinks(client):
+    with app.app_context():
+        target = Post.query.filter_by(path='p2').first()
+        assert target is not None
+        link = PostLink.query.filter_by(target_id=target.id).first()
+        assert link is not None
+        resp = client.get(f'/post/{target.id}/backlinks')
+        assert resp.status_code == 200
+        assert b'P1' in resp.data


### PR DESCRIPTION
## Summary
- store outgoing wikilinks in new PostLink table
- expose `/post/<id>/backlinks` page listing posts linking to target
- show backlinks link from post detail view
- test backlink creation and route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a082d7099483298dad62046a1d772a