### PR TITLE
Add unified Markdown and wiki parser

### DIFF
--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import render_markdown
+
+
+def test_render_markdown_and_wikilink():
+    html, toc = render_markdown('**bold** and [[Page|link]]')
+    assert '<strong>bold</strong>' in html
+    assert '<a href="/docs/Page">link</a>' in html
+    assert toc == ''


### PR DESCRIPTION
## Summary
- add `render_markdown` helper to render Markdown with wiki links and optional TOC
- use unified parser for post display, document pages, and preview endpoint
- cover parsing behavior with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08de0764c8329b9ab400f40bf0838