### PR TITLE
feat: add artistic bootstrap theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,23 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
+body {
+  font-family: 'Playfair Display', serif;
+  margin: 0;
+  background: linear-gradient(120deg, #f6d365 0%, #fda085 100%);
+  min-height: 100vh;
+}
+
+.navbar {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(4px);
+}
+
+.container {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-top: 2rem;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
+}
+
 nav a { margin-right: 10px; }
 textarea { width: 100%; }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}{{ _('Wiki Board') }}{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/sketchy/bootstrap.min.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">


### PR DESCRIPTION
## Summary
- use Bootswatch Sketchy theme and Playfair Display font for a more artistic interface
- add gradient background and translucent container styling for visual flair

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a08e000e6483299c4763341831128d