### PR TITLE
Add viewport meta tag for responsive layout

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ _('Wiki Board') }}{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">


### PR DESCRIPTION
## Summary
- add responsive viewport meta tag to base template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09272a00083299a3b2272d8d82d1d