### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,13 +1,73 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
-nav a { margin-right: 10px; }
-textarea { width: 100%; }
+/* Color variables */
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --nav-bg-color: #f8f9fa;
+  --border-color: #cccccc;
+  --toc-bg-color: #f9f9f9;
+  --link-color: #0d6efd;
+  --navbar-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0, 0, 0, 0.55)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+/* Dark mode overrides */
+.dark-mode {
+  --background-color: #121212;
+  --text-color: #ffffff;
+  --nav-bg-color: #1e1e1e;
+  --border-color: #444444;
+  --toc-bg-color: #2c2c2c;
+  --link-color: #66bfff;
+  --navbar-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255, 255, 255, 0.55)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  background: var(--background-color);
+  color: var(--text-color);
+}
+
+nav a {
+  margin-right: 10px;
+  color: var(--text-color) !important;
+}
+
+.navbar {
+  background-color: var(--nav-bg-color) !important;
+}
+
+.navbar .navbar-brand,
+.navbar .nav-link,
+#theme-toggle {
+  color: var(--text-color) !important;
+  border-color: var(--text-color) !important;
+}
+
+.navbar-toggler {
+  border-color: var(--text-color) !important;
+}
+
+.navbar-toggler-icon {
+  background-image: var(--navbar-toggler-icon);
+}
+
+a {
+  color: var(--link-color);
+}
+
+textarea {
+  width: 100%;
+  background: var(--background-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
 
 .post-layout { display: flex; }
 .toc-container {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   padding: 10px;
   margin-right: 20px;
-  background: #f9f9f9;
+  background: var(--toc-bg-color);
   min-width: 200px;
 }
 .toc-container .toc { margin: 0; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('Home') }}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -36,6 +36,7 @@
           <a class="nav-link" href="{{ url_for('login') }}">{{ _('Login') }}</a>
           <a class="nav-link" href="{{ url_for('register') }}">{{ _('Register') }}</a>
         {% endif %}
+        <button id="theme-toggle" class="btn btn-outline-secondary ms-2" type="button" aria-label="{{ _('Toggle theme') }}">🌓</button>
       </div>
     </div>
   </div>
@@ -125,6 +126,17 @@
         modal.show();
       })
       .catch(() => { window.location.href = url; });
+  });
+</script>
+<script>
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme === 'dark') {
+    document.body.classList.add('dark-mode');
+  }
+  document.getElementById('theme-toggle').addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const theme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+    localStorage.setItem('theme', theme);
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add CSS variables for light and dark themes
- add theme toggle button and persistence using localStorage
- apply variable-based colors across site

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a09273d3348329be12b594bda3fc17