### PR TITLE
Use Bootstrap grid for post detail layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,7 +2,6 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 10px; }
 textarea { width: 100%; }
 
-.post-layout { display: flex; }
 .toc-container {
   border: 1px solid #ccc;
   padding: 10px;
@@ -13,7 +12,6 @@ textarea { width: 100%; }
 .toc-container .toc { margin: 0; }
 .toc-container .toc ul { list-style: none; padding-left: 0; }
 .toc-container .toc a { text-decoration: none; }
-.post-body { flex: 1; }
 
 #map {
   height: 400px;

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -3,14 +3,22 @@
 {% block content %}
 <h1>{{ post.title }} ({{ post.language }})</h1>
 <p><small>{{ post.path }}</small></p>
-<div class="post-layout">
+<div class="row">
   {% if toc %}
-  <nav class="toc-container">
-    <h2>{{ _('Contents') }}</h2>
-    {{ toc|safe }}
-  </nav>
+  <div class="col-md-3">
+    <nav class="toc-container">
+      <h2>{{ _('Contents') }}</h2>
+      {{ toc|safe }}
+    </nav>
+  </div>
+  <div class="col-md-9">
+    <div class="post-body">{{ html_body|safe }}</div>
+  </div>
+  {% else %}
+  <div class="col-md-12">
+    <div class="post-body">{{ html_body|safe }}</div>
+  </div>
   {% endif %}
-  <div class="post-body">{{ html_body|safe }}</div>
 </div>
 <p>{{ _('Tags') }}:
   {% for tag in post.tags %}


### PR DESCRIPTION
## Summary
- Replace custom post layout with Bootstrap row/col structure in `post_detail.html`
- Remove obsolete `.post-layout` and `.post-body` styles

## Testing
- `pytest`
- `python - <<'PY' ...` (ensured Bootstrap grid classes present)


------
https://chatgpt.com/codex/tasks/task_e_68a09274aa84832996d31219f39e17ed