### PR TITLE
Add alt attribute to ogImage image

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <img id="ogImage" class="img-fluid mb-3" style="display:none;">
+        <img id="ogImage" alt="" class="img-fluid mb-3" style="display:none;">
         <p id="ogDescription"></p>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- add `alt` attribute to the modal image for open graph preview
- audit templates for other `<img>` tags (none found)

## Testing
- `pytest`
- `npx --yes lighthouse http://127.0.0.1:5000 --only-categories=accessibility --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0927558ec8329902d6968846c2b13