### PR TITLE
Extract inline scripts to external main.js

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const socket = io();
+  const body = document.body;
+  const currentUserId = body.dataset.currentUserId ? parseInt(body.dataset.currentUserId, 10) : null;
+  const notifUrl = body.dataset.notifUrl;
+  const notifLabel = body.dataset.notifLabel;
+
+  socket.on('new_post', data => {
+    const list = document.getElementById('post-list');
+    if (list) {
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = "/docs/" + data.language + "/" + data.path;
+      link.textContent = data.title;
+      item.appendChild(link);
+      list.prepend(item);
+    }
+  });
+
+  socket.on('new_notification', data => {
+    if (currentUserId && data.user_id === currentUserId) {
+      const link = document.querySelector(`a[href="${notifUrl}"]`);
+      if (link) {
+        const match = link.textContent.match(/\((\d+)\)/);
+        let count = match ? parseInt(match[1], 10) + 1 : 1;
+        link.textContent = `${notifLabel} (${count})`;
+      }
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    const anchor = e.target.closest('a');
+    if (!anchor) return;
+    const url = anchor.href;
+    if (!url.startsWith('http') || anchor.host === window.location.host) return;
+    e.preventDefault();
+    fetch(`/og?url=${encodeURIComponent(url)}`)
+      .then(r => r.json())
+      .then(data => {
+        document.getElementById('ogTitle').textContent = data.title || url;
+        document.getElementById('ogDescription').textContent = data.description || '';
+        const img = document.getElementById('ogImage');
+        if (data.image) {
+          img.src = data.image;
+          img.style.display = 'block';
+        } else {
+          img.style.display = 'none';
+        }
+        const cont = document.getElementById('ogContinue');
+        cont.onclick = () => { window.location.href = url; };
+        cont.href = url;
+        const modal = new bootstrap.Modal(document.getElementById('ogModal'));
+        modal.show();
+      })
+      .catch(() => { window.location.href = url; });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,9 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
-<body>
+<body data-current-user-id="{{ current_user.id if current_user.is_authenticated else '' }}"
+      data-notif-url="{{ url_for('notifications') }}"
+      data-notif-label="{{ _('Notifications') }}">
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">{{ _('Home') }}</a>
@@ -70,62 +72,6 @@
 </div>
 <script src="https://cdn.socket.io/4.7.4/socket.io.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-  const socket = io();
-  const currentUserId = {{ current_user.id if current_user.is_authenticated else 'null' }};
-  const notifUrl = "{{ url_for('notifications') }}";
-  const notifLabel = "{{ _('Notifications') }}";
-
-  socket.on('new_post', data => {
-    const list = document.getElementById('post-list');
-    if (list) {
-      const item = document.createElement('li');
-      const link = document.createElement('a');
-      link.href = "/docs/" + data.language + "/" + data.path;
-      link.textContent = data.title;
-      item.appendChild(link);
-      list.prepend(item);
-    }
-  });
-
-  socket.on('new_notification', data => {
-    if (currentUserId && data.user_id === currentUserId) {
-      const link = document.querySelector('a[href="' + notifUrl + '"]');
-      if (link) {
-        const match = link.textContent.match(/\((\d+)\)/);
-        let count = match ? parseInt(match[1]) + 1 : 1;
-        link.textContent = `${notifLabel} (${count})`;
-      }
-    }
-  });
-</script>
-<script>
-  document.addEventListener('click', function (e) {
-    const anchor = e.target.closest('a');
-    if (!anchor) return;
-    const url = anchor.href;
-    if (!url.startsWith('http') || anchor.host === window.location.host) return;
-    e.preventDefault();
-    fetch(`/og?url=${encodeURIComponent(url)}`)
-      .then(r => r.json())
-      .then(data => {
-        document.getElementById('ogTitle').textContent = data.title || url;
-        document.getElementById('ogDescription').textContent = data.description || '';
-        const img = document.getElementById('ogImage');
-        if (data.image) {
-          img.src = data.image;
-          img.style.display = 'block';
-        } else {
-          img.style.display = 'none';
-        }
-        const cont = document.getElementById('ogContinue');
-        cont.onclick = () => { window.location.href = url; };
-        cont.href = url;
-        const modal = new bootstrap.Modal(document.getElementById('ogModal'));
-        modal.show();
-      })
-      .catch(() => { window.location.href = url; });
-  });
-</script>
+<script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Move inline Socket.IO and link preview scripts from `base.html` into new `static/main.js`
- Pass dynamic values via `data-` attributes and load `main.js` via a single script tag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a09277f4288329b62ae0ac7b8e9ed1