### PR TITLE
Soft delete posts while preserving revisions

### DIFF
--- a/app.py
+++ b/app.py
@@ -986,7 +986,17 @@ def delete_post(post_id: int):
     if post.author_id != current_user.id and not current_user.is_admin():
         flash(_('Permission denied.'))
         return redirect(url_for('post_detail', post_id=post.id))
-    db.session.delete(post)
+    rev = Revision(
+        post=post,
+        user=current_user,
+        title=post.title,
+        body=post.body,
+        path=post.path,
+        language=post.language,
+    )
+    db.session.add(rev)
+    post.title = ''
+    post.body = ''
     db.session.commit()
     flash(_('Post deleted.'))
     return redirect(url_for('index'))

--- a/tests/test_delete_post.py
+++ b/tests/test_delete_post.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_delete_post_clears_content_and_preserves_revisions(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        post_id = post.id
+        revisions = Revision.query.filter_by(post_id=post_id).all()
+        assert len(revisions) == 1
+    resp = client.post(f'/post/{post_id}/delete')
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.get(post_id)
+        assert post.title == ''
+        assert post.body == ''
+        revisions = Revision.query.filter_by(post_id=post_id).order_by(Revision.id).all()
+        assert len(revisions) == 2
+        assert revisions[-1].body == 'Body'


### PR DESCRIPTION
## Summary
- Avoid IntegrityError when deleting posts by retaining records and clearing content
- Preserve edit history by storing a revision before post content is erased
- Add regression test for post deletion behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c30023c0832989859ad54e878b01