### PR TITLE
Fix dark mode theme overriding on page body

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ _('Wiki Board') }}{% endblock %}</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">


### PR DESCRIPTION
## Summary
- Ensure dark mode CSS variables override Bootstrap defaults by loading custom stylesheet after Bootstrap.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c31741b08329b2ae6138876b4d9e