### PR TITLE
fix: apply dark mode colors to lists

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,13 @@
   --border-color: #cccccc;
   --toc-bg-color: #f9f9f9;
   --link-color: #0d6efd;
+  --bs-body-bg: var(--background-color);
+  --bs-body-color: var(--text-color);
+  --bs-border-color: var(--border-color);
+  --bs-link-color: var(--link-color);
+  --bs-list-group-bg: var(--background-color);
+  --bs-list-group-color: var(--text-color);
+  --bs-list-group-border-color: var(--border-color);
   --navbar-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(0, 0, 0, 0.55)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 


### PR DESCRIPTION
## Summary
- ensure Bootstrap list-group elements follow dark theme

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c566a87883298a582e7838df2401