### PR TITLE
Fix dark mode styling for form fields

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -62,17 +62,17 @@ a {
   color: var(--link-color);
 }
 
-textarea {
-  width: 100%;
-  background: var(--background-color);
-  color: var(--text-color);
-  border: 1px solid var(--border-color);
+textarea,
+.form-control {
+  background-color: var(--background-color) !important;
+  color: var(--text-color) !important;
+  border: 1px solid var(--border-color) !important;
 }
 
-.form-control {
-  background: var(--background-color);
-  color: var(--text-color);
-  border: 1px solid var(--border-color);
+textarea::placeholder,
+.form-control::placeholder {
+  color: var(--text-color) !important;
+  opacity: 0.7;
 }
 
 .toc-container {


### PR DESCRIPTION
## Summary
- ensure text inputs and textareas use dark backgrounds and light text when dark mode is enabled
- style placeholder text to match dark theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c74107948329ac3c7f1e16d39803