### PR TITLE
Keep revision diffs accessible after deletions

### DIFF
--- a/templates/diff.html
+++ b/templates/diff.html
@@ -3,5 +3,7 @@
 {% block content %}
 <h1>{{ _('Diff for %(title)s', title=post.title) }}</h1>
 <pre>{{ diff }}</pre>
+{% if post_exists %}
 <p><a href="{{ url_for('history', post_id=post.id) }}">{{ _('Back to history') }}</a></p>
+{% endif %}
 {% endblock %}

--- a/templates/recent.html
+++ b/templates/recent.html
@@ -4,7 +4,7 @@
 <h1>{{ _('Recent changes') }}</h1>
 <ul class="list-group">
   {% for rev in revisions %}
-    <li class="list-group-item">{{ rev.created_at }} - <a href="{{ url_for('document', language=rev.language, doc_path=rev.path) }}">{{ rev.title }}</a> {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a></li>
+    <li class="list-group-item">{{ rev.created_at }} - <a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ rev.title }}</a> {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a></li>
   {% else %}
     <li class="list-group-item">{{ _('No revisions yet.') }}</li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- Allow `/post/<id>/diff/<rev>` to render even if the post no longer exists by diffing against an empty body
- Link the Recent changes page directly to revision diffs and show history link only when the post remains
- Add regression tests for accessing diffs after deletions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c7b79c4c83298c82c865e1c92d4d