### PR TITLE
Add configurable home page path

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,12 +1,16 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Settings') }}{% endblock %}
 {% block content %}
-<h2>{{ _('Global Settings') }}</h2>
-<form method="post">
-  <div class="mb-3">
-    <label for="site_title" class="form-label">{{ _('Site title') }}</label>
-    <input type="text" id="site_title" name="site_title" class="form-control" value="{{ site_title }}">
-  </div>
-  <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
-</form>
+  <h2>{{ _('Global Settings') }}</h2>
+  <form method="post">
+    <div class="mb-3">
+      <label for="site_title" class="form-label">{{ _('Site title') }}</label>
+      <input type="text" id="site_title" name="site_title" class="form-control" value="{{ site_title }}">
+    </div>
+    <div class="mb-3">
+      <label for="home_page_path" class="form-label">{{ _('Home page path') }}</label>
+      <input type="text" id="home_page_path" name="home_page_path" class="form-control" value="{{ home_page_path }}">
+    </div>
+    <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
+  </form>
 {% endblock %}

--- a/tests/test_home_page_setting.py
+++ b/tests/test_home_page_setting.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Setting
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_home_page_redirect(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        post = Post(title='Home', body='Content', path='home', language='en', author=user)
+        db.session.add(post)
+        db.session.add(Setting(key='home_page_path', value='home'))
+        db.session.commit()
+
+    resp = client.get('/')
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/docs/en/home')

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -330,3 +330,11 @@ msgstr "No se encontraron publicaciones."
 msgid "No tags yet."
 msgstr "Aún no hay etiquetas."
 
+#: templates/settings.html:7
+msgid "Site title"
+msgstr "Título del sitio"
+
+#: templates/settings.html:11
+msgid "Home page path"
+msgstr "Ruta de la página principal"
+


### PR DESCRIPTION
## Summary
- allow setting a custom home page path and render that document instead of post list
- expose home page path in settings form and Spanish translations
- test redirect to configured home page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c95289a08329a8fc86760be214eb