### PR TITLE
Fix dropdown menu colors for dark mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -58,6 +58,22 @@ nav a {
   background-image: var(--navbar-toggler-icon);
 }
 
+.dropdown-menu {
+  background-color: var(--nav-bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.dropdown-item {
+  color: var(--text-color);
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus {
+  background-color: var(--toc-bg-color);
+  color: var(--text-color);
+}
+
 a {
   color: var(--link-color);
 }


### PR DESCRIPTION
## Summary
- Ensure dropdown menus use theme variables so list menu works in dark mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c968c0188329b20c8974a1f08d91