### PR TITLE
feat: add GIS map for tags

### DIFF
--- a/app.py
+++ b/app.py
@@ -1464,7 +1464,25 @@ def settings():
 @app.route('/tags')
 def tag_list():
     tags = Tag.query.order_by(Tag.name).all()
-    return render_template('tag_list.html', tags=tags)
+    tag_locations = []
+    for tag in tags:
+        post = next(
+            (p for p in tag.posts if p.latitude is not None and p.longitude is not None),
+            None,
+        )
+        if post is not None:
+            tag_locations.append(
+                {
+                    'name': tag.name,
+                    'lat': post.latitude,
+                    'lon': post.longitude,
+                    'url': url_for('tag_filter', name=tag.name),
+                }
+            )
+    tag_locations_json = json.dumps(tag_locations)
+    return render_template(
+        'tag_list.html', tags=tags, tag_locations_json=tag_locations_json
+    )
 
 
 @app.route('/tag/<string:name>')

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% block title %}{{ _('Tags') }}{% endblock %}
 {% block content %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
 <h1>{{ _('Tags') }}</h1>
+<div id="tag-map" style="height:400px" class="mb-3"></div>
 <ul class="list-group">
   {% for tag in tags %}
     <li class="list-group-item"><a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a></li>
@@ -9,4 +11,16 @@
     <li class="list-group-item">{{ _('No tags yet.') }}</li>
   {% endfor %}
 </ul>
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+<script>
+const tagLocations = {{ tag_locations_json|safe }};
+const map = L.map('tag-map').setView([0, 0], 2);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+tagLocations.forEach(t => {
+  const marker = L.marker([t.lat, t.lon]).addTo(map);
+  marker.bindPopup(`<a href="${t.url}">${t.name}</a>`);
+});
+</script>
 {% endblock %}

--- a/tests/test_tags_map.py
+++ b/tests/test_tags_map.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Tag
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        tag = Tag(name='t1')
+        db.session.add_all([user, tag])
+        db.session.commit()
+        post = Post(
+            title='Post1',
+            body='body',
+            path='p1',
+            language='en',
+            author_id=user.id,
+            latitude=10.0,
+            longitude=20.0,
+            tags=[tag],
+        )
+        db.session.add(post)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_tags_page_includes_locations(client):
+    resp = client.get('/tags')
+    data = resp.get_data(as_text=True)
+    assert 'tagLocations' in data
+    assert '"lat": 10.0' in data
+    assert '/tag/t1' in data


### PR DESCRIPTION
## Summary
- show tags with GIS markers on a Leaflet map
- compute tag locations from post coordinates
- test that /tags outputs tagLocations script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9b4bc6c8329a596c226ef69ebef