### PR TITLE
Improve dark mode styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -107,6 +107,43 @@ textarea::placeholder,
 .toc-container .toc ul { list-style: none; padding-left: 0; }
 .toc-container .toc a { text-decoration: none; }
 
+.alert {
+  background-color: var(--nav-bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.modal-content {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.modal-header,
+.modal-footer {
+  border-color: var(--border-color);
+}
+
+pre {
+  background-color: var(--nav-bg-color);
+  color: var(--text-color);
+  padding: 10px;
+  overflow-x: auto;
+}
+
+.table {
+  --bs-table-bg: var(--background-color);
+  --bs-table-color: var(--text-color);
+  --bs-table-border-color: var(--border-color);
+  --bs-table-striped-bg: var(--toc-bg-color);
+  --bs-table-hover-bg: var(--toc-bg-color);
+}
+
+.error-message {
+  color: var(--text-color);
+  font-weight: bold;
+}
+
 #map {
   height: 400px;
   width: 100%;

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -2,7 +2,7 @@
 {% block title %}{{ _('Citation Statistics') }}{% endblock %}
 {% block content %}
 <h1>{{ _('Citation Statistics') }}</h1>
-<table>
+  <table class="table">
   <tr>
     <th>{{ _('DOI / Citation') }}</th>
     <th>{{ _('Usage Count') }}</th>

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -43,7 +43,7 @@
   <div id="map" style="height:300px"></div>
   <input type="hidden" name="lat" id="lat" value="{{ lat or '' }}">
   <input type="hidden" name="lon" id="lon" value="{{ lon or '' }}">
-  <p id="geocode-error" style="color:red"></p>
+    <p id="geocode-error" class="error-message"></p>
   <div class="mb-3">
     <label for="metadata">{{ _('Post metadata (JSON)') }}</label>
     <textarea name="metadata" id="metadata" class="form-control d-none" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea>


### PR DESCRIPTION
## Summary
- Enhance dark mode support for alerts, modals, code blocks, and tables
- Replace inline geocode error styling with theme-aware class
- Apply Bootstrap table styling to citation stats page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cbc5ef148329b1277a6b6804f216