### PR TITLE
Fix citation layout overflow

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -56,7 +56,7 @@
   <h3>{{ _('Global') }}</h3>
   <ul class="list-group">
     {% for c in citations %}
-      <li class="list-group-item">
+      <li class="list-group-item text-break">
         <strong>{{ c.citation_part|format_metadata }}:</strong>
         {{ c.citation_text }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
@@ -75,7 +75,7 @@
   <h3>{{ _('Your Citations') }}</h3>
   <ul class="list-group">
     {% for c in user_citations %}
-      <li class="list-group-item">
+      <li class="list-group-item text-break">
         <strong>{{ c.citation_part|format_metadata }}:</strong>
         {{ c.citation_text }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,


### PR DESCRIPTION
## Summary
- Prevent long citation metadata from breaking layout by wrapping lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0cd4585c88329824b7ea320be5417