### PR TITLE
Track document view counts and revamp tag page

### DIFF
--- a/app.py
+++ b/app.py
@@ -543,6 +543,24 @@ class UserPostMetadata(db.Model):
     user = db.relationship('User')
 
 
+def get_view_count(post: Post) -> int:
+    """Return total view count for a post."""
+    meta = next((m for m in post.metadata if m.key == 'views'), None)
+    return int(meta.value) if meta else 0
+
+
+def increment_view_count(post: Post) -> int:
+    """Increment and return the view count for a post."""
+    meta = PostMetadata.query.filter_by(post_id=post.id, key='views').first()
+    if meta:
+        meta.value = int(meta.value) + 1
+    else:
+        meta = PostMetadata(post=post, key='views', value=1)
+        db.session.add(meta)
+    db.session.commit()
+    return int(meta.value)
+
+
 class Notification(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
@@ -927,6 +945,7 @@ def create_post():
 @app.route('/post/<int:post_id>')
 def post_detail(post_id: int):
     post = Post.query.get_or_404(post_id)
+    views = increment_view_count(post)
     post_meta = {m.key: m.value for m in post.metadata}
     location, warning = extract_location(post_meta)
     geodata = extract_geodata(post_meta)
@@ -964,6 +983,7 @@ def post_detail(post_id: int):
         user_metadata=user_meta,
         citations=citations,
         user_citations=user_citations,
+        views=views,
     )
 
 
@@ -1037,6 +1057,7 @@ def document(language: str, doc_path: str):
                 url_for('document', language=language, doc_path=redirect_entry.new_path)
             )
         abort(404)
+    views = increment_view_count(post)
     post_meta = {m.key: m.value for m in post.metadata}
     user_meta = {}
     citations = (
@@ -1070,7 +1091,8 @@ def document(language: str, doc_path: str):
         metadata=post_meta,
         user_metadata=user_meta,
         citations=citations,
-    user_citations=user_citations,
+        user_citations=user_citations,
+        views=views,
     )
 
 
@@ -1482,6 +1504,7 @@ def settings():
 def tag_list():
     tags = Tag.query.order_by(Tag.name).all()
     tag_locations = []
+    tag_info = []
     for tag in tags:
         post = next(
             (p for p in tag.posts if p.latitude is not None and p.longitude is not None),
@@ -1496,9 +1519,15 @@ def tag_list():
                     'url': url_for('tag_filter', name=tag.name),
                 }
             )
+        top_posts = sorted(
+            [(p, get_view_count(p)) for p in tag.posts],
+            key=lambda x: x[1],
+            reverse=True,
+        )[:3]
+        tag_info.append({'tag': tag, 'top_posts': top_posts})
     tag_locations_json = json.dumps(tag_locations)
     return render_template(
-        'tag_list.html', tags=tags, tag_locations_json=tag_locations_json
+        'tag_list.html', tag_info=tag_info, tag_locations_json=tag_locations_json
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -156,3 +156,25 @@ pre {
     height: 300px;
   }
 }
+
+.tag-card {
+  border: 1px solid var(--border-color);
+  background-color: var(--nav-bg-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+}
+
+.tag-card ul {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+
+.tag-card li {
+  font-size: 0.9rem;
+}
+
+.tag-card h5 {
+  margin: 0 0 0.5rem 0;
+}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>{{ post.title }} ({{ post.language }})</h1>
 <p><small>{{ post.path }}</small></p>
+<p><small>{{ _('Views') }}: {{ views }}</small></p>
 <div class="row">
   {% if toc %}
   <div class="col-md-3">

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -4,13 +4,27 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
 <h1>{{ _('Tags') }}</h1>
 <div id="tag-map" style="height:400px" class="mb-3"></div>
-<ul class="list-group">
-  {% for tag in tags %}
-    <li class="list-group-item"><a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a></li>
-  {% else %}
-    <li class="list-group-item">{{ _('No tags yet.') }}</li>
+{% if tag_info %}
+<div class="d-flex flex-wrap">
+  {% for item in tag_info %}
+    {% set tag = item.tag %}
+    <div class="tag-card">
+      <h5><a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a></h5>
+      {% if item.top_posts %}
+      <ul>
+        {% for post, views in item.top_posts %}
+          <li><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> ({{ views }})</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-muted mb-0 small">{{ _('No posts yet.') }}</p>
+      {% endif %}
+    </div>
   {% endfor %}
-</ul>
+</div>
+{% else %}
+<p>{{ _('No tags yet.') }}</p>
+{% endif %}
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script>
 const tagLocations = {{ tag_locations_json|safe }};

--- a/tests/test_tag_top_views.py
+++ b/tests/test_tag_top_views.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Tag
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        tag = Tag(name='t')
+        db.session.add_all([user, tag])
+        posts = []
+        for i in range(3):
+            p = Post(title=f'P{i}', body='b', path=f'p{i}', language='en', author=user, tags=[tag])
+            posts.append(p)
+            db.session.add(p)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_tags_show_top_posts_by_views(client):
+    client.get('/docs/en/p0')
+    client.get('/docs/en/p1')
+    client.get('/docs/en/p1')
+    client.get('/docs/en/p2')
+    client.get('/docs/en/p2')
+    client.get('/docs/en/p2')
+    resp = client.get('/tags')
+    data = resp.get_data(as_text=True)
+    assert data.index('P2') < data.index('P1') < data.index('P0')

--- a/tests/test_view_count.py
+++ b/tests/test_view_count.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostMetadata
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        post = Post(title='Post', body='body', path='p', language='en', author=user)
+        db.session.add_all([user, post])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_view_count_increment(client):
+    resp = client.get('/docs/en/p')
+    assert resp.status_code == 200
+    with app.app_context():
+        meta = PostMetadata.query.filter_by(key='views').first()
+        assert meta is not None
+        assert meta.value == 1
+    client.get('/docs/en/p')
+    with app.app_context():
+        meta = PostMetadata.query.filter_by(key='views').first()
+        assert meta.value == 2


### PR DESCRIPTION
## Summary
- add Post view count storage and increment logic
- show view counts on documents
- redesign tag page with card layout and top viewed posts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ce13f2a88329ba5b039411246345