### PR TITLE
Fix list group items for dark mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -89,6 +89,12 @@ nav a {
   color: var(--text-color);
 }
 
+.list-group-item {
+  background-color: var(--background-color) !important;
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+}
+
 a {
   color: var(--link-color);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -93,6 +93,7 @@
     const list = document.getElementById('post-list');
     if (list) {
       const item = document.createElement('li');
+      item.classList.add('list-group-item');
       const link = document.createElement('a');
       link.href = "/docs/" + data.language + "/" + data.path;
       link.textContent = data.title;


### PR DESCRIPTION
## Summary
- Ensure list group items use theme variables for background, text, and border colors
- Apply list-group-item class to dynamically inserted posts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cea891d08329b6c08cccbc76bbc2