### PR TITLE
Ensure white text in dark mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -149,6 +149,18 @@ pre {
   --bs-table-hover-bg: var(--toc-bg-color);
 }
 
+.dark-mode .table,
+.dark-mode .table th,
+.dark-mode .table td,
+.dark-mode .pagination .page-link {
+  color: var(--text-color) !important;
+}
+
+.dark-mode .pagination .page-link {
+  background-color: var(--background-color);
+  border-color: var(--border-color);
+}
+
 .error-message {
   color: var(--text-color);
   font-weight: bold;


### PR DESCRIPTION
## Summary
- ensure tables and pagination links use white text in dark mode for better contrast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cefb659c8329acb9b6a8c093a25a