### PR TITLE
Handle missing timezone data for recent changes page

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from dotenv import load_dotenv
 from geopy.geocoders import Nominatim
 from geopy.distance import distance as geopy_distance
 from langdetect import detect, DetectorFactory, LangDetectException
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 load_dotenv()
 DetectorFactory.seed = 0
@@ -738,7 +738,10 @@ def recent_changes():
         Revision.query.order_by(Revision.created_at.desc()).limit(20).all()
     )
     tz_name = get_setting('timezone', 'UTC') or 'UTC'
-    tzinfo = ZoneInfo(tz_name)
+    try:
+        tzinfo = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        tzinfo = timezone.utc
     for rev in revisions:
         dt = rev.created_at.replace(tzinfo=timezone.utc).astimezone(tzinfo)
         rev.display_time = dt.strftime('%Y-%m-%d %H:%M %Z')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ markdown==3.5.1
 python-dotenv==1.0.1
 redis==5.0.0
 requests==2.31.0
+tzdata==2024.1


### PR DESCRIPTION
## Summary
- avoid crashes when timezone info is missing by falling back to UTC
- declare tzdata dependency for built-in timezone database

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d25427988329a51d04b51857b2bc