### PR TITLE
Fix geocode caching for address lookups

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,8 @@ def geocode_address(address: str) -> tuple[float, float] | None:
         try:
             cached = geocode_cache.get(address)
             if cached:
+                if isinstance(cached, bytes):
+                    cached = cached.decode()
                 lat_str, lon_str = cached.split(",")
                 return float(lat_str), float(lon_str)
         except Exception:

--- a/tests/test_geocode_cache.py
+++ b/tests/test_geocode_cache.py
@@ -65,3 +65,21 @@ def test_geocode_cache_failure(monkeypatch):
     result = app.geocode_address('another address')
     assert result == (5.0, 6.0)
     assert calls['count'] == 1
+
+
+def test_geocode_address_cache_bytes(monkeypatch):
+    cache = DummyCache()
+    cache.setex('byte addr', 60, b'3.0,4.0')
+    monkeypatch.setattr(app, 'geocode_cache', cache)
+
+    calls = {'count': 0}
+
+    def fake_geocode(_):
+        calls['count'] += 1
+        return None
+
+    monkeypatch.setattr(app.geolocator, 'geocode', fake_geocode)
+
+    result = app.geocode_address('byte addr')
+    assert result == (3.0, 4.0)
+    assert calls['count'] == 0


### PR DESCRIPTION
## Summary
- decode cached byte strings when returning coordinates
- test geocode cache for byte values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d3236d2c8329b4d799aafbef4909