### PR TITLE
Add direct post links to recent changes

### DIFF
--- a/templates/recent.html
+++ b/templates/recent.html
@@ -6,7 +6,8 @@
     {% for rev in revisions %}
       <li class="list-group-item">
         {{ rev.display_time }} -
-        <a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ rev.title }}</a>
+        <a href="{{ url_for('post_detail', post_id=rev.post_id) }}">{{ rev.title }}</a>
+        (<a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ _('diff') }}</a>)
         {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a>
         {% if rev.comment %} — {{ rev.comment }}{% endif %}
         <span class="text-muted">({{ '+' if rev.byte_change >= 0 else ''}}{{ rev.byte_change }})</span>

--- a/tests/test_delete_post.py
+++ b/tests/test_delete_post.py
@@ -102,6 +102,7 @@ def test_recent_page_links_to_diff_for_deleted_post(client):
     assert resp.status_code == 302
     resp = client.get('/recent')
     assert resp.status_code == 200
+    assert f'/post/{post_id}'.encode() in resp.data
     assert f'/post/{post_id}/diff/{rev_id}'.encode() in resp.data
     resp = client.get(f'/post/{post_id}/diff/{rev_id}')
     assert resp.status_code == 200

--- a/tests/test_recent_changes.py
+++ b/tests/test_recent_changes.py
@@ -61,3 +61,28 @@ def test_recent_changes_show_comment_and_delta(client):
     assert b'(+4)' in resp.data
     assert b'edit' in resp.data
     assert b'(+1)' in resp.data
+
+
+def test_recent_changes_links_to_post_and_diff(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        post_id = post.id
+        revision = post.revisions[0]
+        rev_id = revision.id
+    resp = client.get('/recent')
+    assert resp.status_code == 200
+    assert f'/post/{post_id}'.encode() in resp.data
+    assert f'/post/{post_id}/diff/{rev_id}'.encode() in resp.data


### PR DESCRIPTION
## Summary
- Link titles in recent changes to the post detail page
- Keep diff action as a separate link
- Cover behavior with new tests including deleted posts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d41687208329b0d44d3a7d2ce697