### PR TITLE
Render citations with MLA formatting and normalized DOIs

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -10,7 +10,7 @@
   </tr>
   {% for item in stats %}
   <tr>
-    <td>{% if item.doi %}{{ item.doi }}{% else %}{{ item.citation_text }}{% endif %}</td>
+    <td>{% if item.doi %}<a href="https://doi.org/{{ item.doi }}">{{ item.doi }}</a>{% else %}{{ item.citation_text }}{% endif %}</td>
     <td>{{ item.count }}</td>
     <td>
       {% for post in item.posts %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -58,8 +58,7 @@
   <ul class="list-group">
     {% for c in citations %}
       <li class="list-group-item text-break">
-        <strong>{{ c.citation_part|format_metadata }}:</strong>
-        {{ c.citation_text }}
+        {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
@@ -77,8 +76,7 @@
   <ul class="list-group">
     {% for c in user_citations %}
       <li class="list-group-item text-break">
-        <strong>{{ c.citation_part|format_metadata }}:</strong>
-        {{ c.citation_text }}
+        {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
         <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>

--- a/tests/test_citation_format.py
+++ b/tests/test_citation_format.py
@@ -1,0 +1,23 @@
+from app import format_citation_mla, normalize_doi
+
+def test_normalize_doi():
+    assert normalize_doi('https://doi.org/10.1000/XYZ') == '10.1000/xyz'
+    assert normalize_doi('10.1000/xyz') == '10.1000/xyz'
+    assert normalize_doi(None) is None
+
+def test_format_citation_mla_basic():
+    part = {
+        'author': 'Mercati, Flavio',
+        'title': 'Relativity Without Relativity',
+        'journal': 'Oxford Scholarship Online',
+        'publisher': 'Oxford University Press',
+        'year': '2018'
+    }
+    result = format_citation_mla(part, '10.1093/oso/9780198789475.003.0007')
+    result_str = str(result)
+    assert 'Mercati, Flavio' in result_str
+    assert '"Relativity Without Relativity"' in result_str
+    assert '<em>Oxford Scholarship Online</em>' in result_str
+    assert 'Oxford University Press' in result_str
+    assert '2018' in result_str
+    assert 'https://doi.org/10.1093/oso/9780198789475.003.0007' in result_str


### PR DESCRIPTION
## Summary
- add MLA-style citation formatting filter and DOI normalizer
- normalize DOI values when fetching and saving citations
- link citation DOIs and show MLA-formatted entries in templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d51f1a808329a332074b0f0aa58c