### PR TITLE
Allow admins to comment on requested posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,25 @@ def ensure_revision_comment_column() -> None:
 ensure_revision_comment_column()
 
 
+def ensure_requested_post_comment_column() -> None:
+    with app.app_context():
+        inspector = inspect(db.engine)
+        try:
+            cols = [c["name"] for c in inspector.get_columns("requested_post")]
+        except NoSuchTableError:
+            return
+        if "admin_comment" not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "ALTER TABLE requested_post ADD COLUMN admin_comment VARCHAR(200) DEFAULT ''"
+                    )
+                )
+
+
+ensure_requested_post_comment_column()
+
+
 def fetch_bibtex_by_title(title: str) -> str | None:
     """Return raw BibTeX for the first work matching the given title."""
     if not title:
@@ -598,6 +617,7 @@ class RequestedPost(db.Model):
     description = db.Column(db.Text, nullable=False)
     requester_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    admin_comment = db.Column(db.String(200), default='')
 
     requester = db.relationship('User', backref='requested_posts')
 
@@ -863,6 +883,23 @@ def request_post():
 def requested_posts():
     reqs = RequestedPost.query.order_by(RequestedPost.created_at.desc()).all()
     return render_template('requested_posts.html', requests=reqs)
+
+
+@app.route('/admin/requested', methods=['GET', 'POST'])
+@login_required
+def admin_requested_posts():
+    if not current_user.is_admin():
+        abort(403)
+    if request.method == 'POST':
+        req_id = request.form.get('request_id', type=int)
+        comment = request.form.get('comment', '').strip()
+        req = RequestedPost.query.get_or_404(req_id)
+        req.admin_comment = comment
+        db.session.commit()
+        flash(_('Comment updated'))
+        return redirect(url_for('admin_requested_posts'))
+    reqs = RequestedPost.query.order_by(RequestedPost.created_at.desc()).all()
+    return render_template('admin/requested_posts.html', requests=reqs)
 
 
 def _slugify(title: str) -> str:

--- a/templates/admin/requested_posts.html
+++ b/templates/admin/requested_posts.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Manage Requested Posts') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Manage Requested Posts') }}</h1>
+<ul class="list-group">
+  {% for req in requests %}
+  <li class="list-group-item">
+    <form method="post" class="row g-2 align-items-center">
+      <input type="hidden" name="request_id" value="{{ req.id }}">
+      <div class="col-md-4">
+        <strong>{{ req.title }}</strong><br>
+        <small>{{ req.description }}</small><br>
+        <small><a href="{{ url_for('profile', username=req.requester.username) }}">{{ req.requester.username }}</a></small>
+      </div>
+      <div class="col-md-6">
+        <input type="text" name="comment" class="form-control" value="{{ req.admin_comment }}" placeholder="{{ _('Comment') }}">
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary btn-sm">{{ _('Save') }}</button>
+      </div>
+    </form>
+  </li>
+  {% else %}
+  <li class="list-group-item">{{ _('No requests yet.') }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}">📬</a></li>
         {% if current_user.is_authenticated and current_user.is_admin() %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}">🛠️</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}">📥</a></li>
         {% endif %}
       </ul>
       <form class="d-flex me-3" role="search" action="{{ url_for('search') }}" method="get">

--- a/templates/requested_posts.html
+++ b/templates/requested_posts.html
@@ -5,9 +5,14 @@
 <ul class="list-group">
   {% for req in requests %}
     <li class="list-group-item">
+      <div>
         <strong>{{ req.title }}</strong> - {{ req.description }} (<a href="{{ url_for('profile', username=req.requester.username) }}">{{ req.requester.username }}</a>)
-      {% if current_user.is_authenticated %}
-      <a href="{{ url_for('create_post', request_id=req.id) }}" class="btn btn-sm btn-secondary ms-2">{{ _('Convert to Post') }}</a>
+        {% if current_user.is_authenticated %}
+        <a href="{{ url_for('create_post', request_id=req.id) }}" class="btn btn-sm btn-secondary ms-2">{{ _('Convert to Post') }}</a>
+        {% endif %}
+      </div>
+      {% if req.admin_comment %}
+      <div class="mt-1 text-muted small">{{ req.admin_comment }}</div>
       {% endif %}
     </li>
   {% else %}

--- a/tests/test_admin_requested_posts.py
+++ b/tests/test_admin_requested_posts.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, RequestedPost
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        requester = User(username='req', role='user')
+        requester.set_password('pw')
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        db.session.add_all([requester, admin])
+        db.session.commit()
+        req = RequestedPost(title='Need', description='Desc', requester=requester)
+        db.session.add(req)
+        db.session.commit()
+        req_id = req.id
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'admin', 'password': 'pw'})
+        yield client, req_id
+    with app.app_context():
+        db.drop_all()
+
+
+def test_admin_can_add_comment(client):
+    client, req_id = client
+    resp = client.post('/admin/requested', data={'request_id': req_id, 'comment': 'processing'}, follow_redirects=True)
+    assert resp.status_code == 200
+    resp = client.get('/posts/requested')
+    assert b'processing' in resp.data


### PR DESCRIPTION
## Summary
- Let admins attach brief comments to requested posts
- Provide an admin page to manage requests and comments
- Display admin comments on public requested posts page

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d5b680dc83299bda99871ec765e9