### PR TITLE
feat: add contribution map to profile

### DIFF
--- a/app.py
+++ b/app.py
@@ -820,6 +820,21 @@ def profile(username: str):
         db.session.commit()
         flash(_('Profile updated'))
         return redirect(url_for('profile', username=user.username))
+    post_locations: list[dict[str, float | str]] = []
+    seen_loc_ids: set[int] = set()
+    for p in posts + edited_posts:
+        if p.id in seen_loc_ids:
+            continue
+        seen_loc_ids.add(p.id)
+        if p.latitude is not None and p.longitude is not None:
+            post_locations.append(
+                {
+                    'title': p.title,
+                    'lat': p.latitude,
+                    'lon': p.longitude,
+                    'url': url_for('document', language=p.language, doc_path=p.path),
+                }
+            )
     return render_template(
         'profile.html',
         user=user,
@@ -827,6 +842,8 @@ def profile(username: str):
         edited_posts=edited_posts,
         post_count=post_count,
         citation_count=citation_count,
+        post_locations=post_locations,
+        post_locations_json=json.dumps(post_locations),
     )
 
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -30,6 +30,33 @@
   {% endfor %}
   </ul>
 </section>
+{% if post_locations %}
+<section>
+  <h2>{{ _('Contribution Map') }}</h2>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <div id="profile-map" style="height: 400px;"></div>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script>
+    const postLocations = {{ post_locations_json|safe }};
+    const map = L.map('profile-map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    const markers = [];
+    postLocations.forEach(p => {
+      const m = L.marker([p.lat, p.lon]).addTo(map);
+      m.bindPopup(`<a href="${p.url}">${p.title}</a>`);
+      markers.push(m);
+    });
+    if (markers.length === 1) {
+      map.setView(markers[0].getLatLng(), 8);
+    } else if (markers.length > 1) {
+      const group = L.featureGroup(markers);
+      map.fitBounds(group.getBounds().pad(0.2));
+    }
+  </script>
+</section>
+{% endif %}
 {% if current_user.is_authenticated and current_user.id == user.id %}
 <section>
   <h2>{{ _('Edit Profile') }}</h2>

--- a/tests/test_profile_map.py
+++ b/tests/test_profile_map.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        u = User(username='u')
+        u.set_password('pw')
+        other = User(username='o')
+        other.set_password('pw')
+        db.session.add_all([u, other])
+        db.session.commit()
+        p1 = Post(
+            title='P1',
+            body='b',
+            path='p1',
+            language='en',
+            author_id=u.id,
+            latitude=10.0,
+            longitude=20.0,
+        )
+        p2 = Post(
+            title='P2',
+            body='b',
+            path='p2',
+            language='en',
+            author_id=other.id,
+            latitude=30.0,
+            longitude=40.0,
+        )
+        db.session.add_all([p1, p2])
+        db.session.commit()
+        rev = Revision(
+            post_id=p2.id,
+            user_id=u.id,
+            title=p2.title,
+            body=p2.body,
+            path=p2.path,
+            language=p2.language,
+        )
+        db.session.add(rev)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_profile_includes_post_locations(client):
+    resp = client.get('/user/u')
+    data = resp.get_data(as_text=True)
+    assert 'postLocations' in data
+    assert '"lat": 10.0' in data
+    assert '"lat": 30.0' in data


### PR DESCRIPTION
## Summary
- show Leaflet map on profile page with posts the user created or edited
- collect post coordinates server-side and pass to template
- add tests for profile contribution map data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d5d8b914832998d30b53f8dc7b36