### PR TITLE
Trigger geocode lookup on Enter in address field

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -76,8 +76,13 @@ const bodyInput = document.querySelector('textarea[name="body"]');
 const previewEl = document.getElementById('preview');
 const formEl = document.querySelector('form');
 formEl.addEventListener('keydown', function (e) {
-  if (e.key === 'Enter' && e.target.tagName !== 'TEXTAREA') {
-    e.preventDefault();
+  if (e.key === 'Enter') {
+    if (e.target.id === 'address-input') {
+      e.preventDefault();
+      document.getElementById('find-coordinates').click();
+    } else if (e.target.tagName !== 'TEXTAREA') {
+      e.preventDefault();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- trigger coordinates lookup when pressing Enter inside the address field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d7c084608329a649d046ea2c1900