### PR TITLE
Replace emoji icons with Bootstrap icons for accessibility

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}{{ get_setting('site_title', _('Wiki Board')) }}{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -16,13 +17,13 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('tag_list') }}" aria-label="{{ _('Tags') }}" title="{{ _('Tags') }}">🔖</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('recent_changes') }}" aria-label="{{ _('Recent changes') }}" title="{{ _('Recent changes') }}">🔄</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}">📊</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}">📬</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('tag_list') }}" aria-label="{{ _('Tags') }}" title="{{ _('Tags') }}"><i class="bi bi-tags" aria-hidden="true"></i><span class="visually-hidden">{{ _('Tags') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('recent_changes') }}" aria-label="{{ _('Recent changes') }}" title="{{ _('Recent changes') }}"><i class="bi bi-clock-history" aria-hidden="true"></i><span class="visually-hidden">{{ _('Recent changes') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}"><i class="bi bi-bar-chart" aria-hidden="true"></i><span class="visually-hidden">{{ _('Citation Stats') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}"><i class="bi bi-mailbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Requested Posts') }}</span></a></li>
         {% if current_user.is_authenticated and current_user.is_admin() %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}">🛠️</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}">📥</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}"><i class="bi bi-tools" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Posts') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}"><i class="bi bi-inbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Requests') }}</span></a></li>
         {% endif %}
       </ul>
       <form class="d-flex me-3" role="search" action="{{ url_for('search') }}" method="get">
@@ -32,7 +33,7 @@
         {% if current_user.is_authenticated %}
           {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
           <li class="nav-item">
-            <a class="nav-link position-relative" href="{{ url_for('notifications') }}" aria-label="{{ _('Notifications') }}" title="{{ _('Notifications') }}" id="notif-link">🔔
+            <a class="nav-link position-relative" href="{{ url_for('notifications') }}" aria-label="{{ _('Notifications') }}" title="{{ _('Notifications') }}" id="notif-link"><i class="bi bi-bell" aria-hidden="true"></i><span class="visually-hidden">{{ _('Notifications') }}</span>
               <span id="notif-count" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" {% if not unread %}style="display:none"{% endif %}>{{ unread }}</span>
             </a>
           </li>
@@ -50,10 +51,10 @@
             </ul>
           </li>
         {% else %}
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}" aria-label="{{ _('Login') }}" title="{{ _('Login') }}">🔑</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}" aria-label="{{ _('Register') }}" title="{{ _('Register') }}">📝</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}" aria-label="{{ _('Login') }}" title="{{ _('Login') }}"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span class="visually-hidden">{{ _('Login') }}</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}" aria-label="{{ _('Register') }}" title="{{ _('Register') }}"><i class="bi bi-pencil-square" aria-hidden="true"></i><span class="visually-hidden">{{ _('Register') }}</span></a></li>
         {% endif %}
-        <li class="nav-item"><button id="theme-toggle" class="btn btn-outline-secondary ms-2" type="button" aria-label="{{ _('Toggle theme') }}">🌓</button></li>
+        <li class="nav-item"><button id="theme-toggle" class="btn btn-outline-secondary ms-2" type="button" aria-label="{{ _('Toggle theme') }}"><i class="bi bi-circle-half" aria-hidden="true"></i><span class="visually-hidden">{{ _('Toggle theme') }}</span></button></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- use Bootstrap Icons instead of emojis
- add visually hidden text labels for navigation links and controls

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: tests/test_view_count.py::test_view_count_not_editable_via_metadata - AttributeError: 'NoneType' object has no attribute 'value')*

------
https://chatgpt.com/codex/tasks/task_e_68a0db35138c83299aea367ffa91c3b5