### PR TITLE
Add collapsible sections to post form

### DIFF
--- a/app.py
+++ b/app.py
@@ -1539,10 +1539,13 @@ def edit_post(post_id: int):
             post.latitude = None
             post.longitude = None
 
+        existing_views = PostMetadata.query.filter_by(post_id=post.id, key='views').first()
         PostMetadata.query.filter_by(post_id=post.id).delete(synchronize_session=False)
 
         for key, value in meta_dict.items():
             db.session.add(PostMetadata(post=post, key=key, value=value))
+        if existing_views:
+            db.session.add(PostMetadata(post=post, key='views', value=existing_views.value))
 
         if user_metadata_json:
             try:

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -33,7 +33,8 @@
     <label for="tags">{{ _('Comma separated tags') }}</label>
     <input name="tags" id="tags" class="form-control" placeholder="{{ _('Comma separated tags') }}" value="{{ tags if tags else '' }}">
   </div>
-  <div class="mb-3">
+  <details id="location-section" class="mb-3">
+    <summary>{{ _('Location') }}</summary>
     <label for="address-input">{{ _('Address') }}</label>
     <div class="row g-2">
       <div class="col-md-6">
@@ -47,16 +48,17 @@
     <input type="hidden" name="lat" id="lat" value="{{ lat or '' }}">
     <input type="hidden" name="lon" id="lon" value="{{ lon or '' }}">
     <p id="geocode-error" class="error-message"></p>
-    <details class="mb-3">
-      <summary>{{ _('Post metadata (JSON)') }}</summary>
-      <textarea name="metadata" id="metadata" class="form-control d-none" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea>
-      <div id="metadata_editor" style="height: 200px;"></div>
-    </details>
-    <details class="mb-3">
-      <summary>{{ _('Your metadata (JSON)') }}</summary>
-      <textarea name="user_metadata" id="user_metadata" class="form-control d-none" placeholder="{{ _('Your metadata (JSON)') }}" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea>
-      <div id="user_metadata_editor" style="height: 200px;"></div>
-    </details>
+  </details>
+  <details class="mb-3">
+    <summary>{{ _('Post metadata (JSON)') }}</summary>
+    <textarea name="metadata" id="metadata" class="form-control d-none" placeholder="{{ _('Post metadata (JSON)') }}" rows="5" cols="50">{{ metadata if metadata else '' }}</textarea>
+    <div id="metadata_editor" style="height: 200px;"></div>
+  </details>
+  <details class="mb-3">
+    <summary>{{ _('Your metadata (JSON)') }}</summary>
+    <textarea name="user_metadata" id="user_metadata" class="form-control d-none" placeholder="{{ _('Your metadata (JSON)') }}" rows="5" cols="50">{{ user_metadata if user_metadata else '' }}</textarea>
+    <div id="user_metadata_editor" style="height: 200px;"></div>
+  </details>
   <div class="mb-3">
     <label for="comment">{{ _('Edit summary') }}</label>
     <input name="comment" id="comment" class="form-control" placeholder="{{ _('Edit summary') }}">
@@ -140,6 +142,12 @@ const drawControl = new L.Control.Draw({
   draw: { polygon:false, polyline:false, rectangle:false, circle:false, circlemarker:false }
 });
 map.addControl(drawControl);
+const locationSection = document.getElementById('location-section');
+locationSection.addEventListener('toggle', () => {
+  if (locationSection.open) {
+    setTimeout(() => map.invalidateSize(), 0);
+  }
+});
 setTimeout(() => map.invalidateSize(), 0);
 
 const latField = document.getElementById('lat');


### PR DESCRIPTION
## Summary
- collapse post form sections such as location and metadata using `<details>`
- refresh map size when location section is opened
- preserve view count metadata when editing posts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0db383644832999eb530c74964c0f