### PR TITLE
feat: add responsive toc sidebar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -119,9 +119,22 @@ textarea::placeholder,
   background: var(--toc-bg-color);
   min-width: 200px;
 }
-.toc-container .toc { margin: 0; }
-.toc-container .toc ul { list-style: none; padding-left: 0; }
-.toc-container .toc a { text-decoration: none; }
+
+.toc-container.sticky-top {
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.toc { margin: 0; }
+.toc ul { list-style: none; padding-left: 0; }
+.toc a { text-decoration: none; }
+
+@media (max-width: 767.98px) {
+  .toc-container {
+    display: none;
+  }
+}
 
 .alert {
   background-color: var(--nav-bg-color);

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -7,10 +7,26 @@
 <div class="row">
   {% if toc %}
   <div class="col-md-3">
-    <nav class="toc-container">
-      <h2>{{ _('Contents') }}</h2>
-      {{ toc|safe }}
-    </nav>
+    <div class="d-none d-md-block">
+      <nav class="toc-container sticky-top">
+        <h2>{{ _('Contents') }}</h2>
+        {{ toc|safe }}
+      </nav>
+    </div>
+    <div class="d-md-none mb-3">
+      <button class="btn btn-secondary" type="button" data-bs-toggle="offcanvas" data-bs-target="#tocOffcanvas" aria-controls="tocOffcanvas">
+        {{ _('Contents') }}
+      </button>
+      <div class="offcanvas offcanvas-start" tabindex="-1" id="tocOffcanvas" aria-labelledby="tocOffcanvasLabel">
+        <div class="offcanvas-header">
+          <h5 class="offcanvas-title" id="tocOffcanvasLabel">{{ _('Contents') }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="{{ _('Close') }}"></button>
+        </div>
+        <div class="offcanvas-body">
+          {{ toc|safe }}
+        </div>
+      </div>
+    </div>
   </div>
   <div class="col-md-9">
     <div class="post-body">{{ html_body|safe }}</div>


### PR DESCRIPTION
## Summary
- make table of contents sticky on large screens
- add offcanvas toggle for ToC on mobile
- style ToC container with media queries for mobile

## Testing
- `pytest` *(fails: tests/test_view_count.py::test_view_count_not_editable_via_metadata - AttributeError: 'NoneType' object has no attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db3a74388329a0a906b9dab6534b