### PR TITLE
Add footer with copyright and links

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -206,3 +206,14 @@ pre {
 .tag-card h5 {
   margin: 0 0 0.5rem 0;
 }
+
+footer {
+  border-top: 1px solid var(--border-color);
+  margin-top: 2rem;
+  padding-top: 1rem;
+  text-align: center;
+}
+
+footer a {
+  margin: 0 0.5rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,6 +68,14 @@
 {% endwith %}
 {% block content %}{% endblock %}
 </div>
+<footer class="footer mt-5 py-3">
+  <div class="container text-center">
+    <p class="mb-1">&copy; {{ get_setting('site_title', _('Wiki Board')) }}</p>
+    <a href="{{ url_for('index') }}">{{ _('Home') }}</a>
+    |
+    <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a>
+  </div>
+</footer>
 <div class="modal fade" id="ogModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- add a footer to the base template with copyright text and navigation links
- style the footer with a top border and centered layout for visual separation

## Testing
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'metadata' in tests/test_view_count.py::test_view_count_not_editable_via_metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db3ba3148329a2c0b3c3a925da8c