### PR TITLE
Add dark-mode support for Leaflet maps

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -174,10 +174,20 @@
 <script>
   const data = { type: 'FeatureCollection', features: {{ geodata|tojson }} };
   const map = L.map('map').setView([0, 0], 2);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+  const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+  const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
+  const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors'
   }).addTo(map);
+  const updateTiles = () => {
+      tiles.setUrl(isDark() ? darkUrl : lightUrl);
+  };
+  const themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+      themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
+  }
   const layer = L.geoJSON(data).addTo(map);
   try {
     map.fitBounds(layer.getBounds());

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -130,9 +130,19 @@ bodyInput.addEventListener('input', updatePreview);
 updatePreview();
 
 const map = L.map('map').setView([0, 0], 2);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
+const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
   attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
+const updateTiles = () => {
+  tiles.setUrl(isDark() ? darkUrl : lightUrl);
+};
+const themeToggle = document.getElementById('theme-toggle');
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
+}
 const drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 const drawControl = new L.Control.Draw({


### PR DESCRIPTION
## Summary
- Swap Leaflet tile layers based on dark mode state
- Ensure map tiles update when toggling theme

## Testing
- `pytest` *(fails: tests/test_view_count.py::test_view_count_not_editable_via_metadata - AttributeError: 'NoneType' object has no attribute 'value')*


------
https://chatgpt.com/codex/tasks/task_e_68a0db3ce5fc83298428222aa2dd03c7