### PR TITLE
feat: add section margin utility class

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -206,3 +206,8 @@ pre {
 .tag-card h5 {
   margin: 0 0 0.5rem 0;
 }
+
+/* Section spacing utility */
+.mb-4 {
+  margin-bottom: 1.5rem !important;
+}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -27,7 +27,7 @@
   {% endfor %}
 </p>
 {% if metadata or user_metadata %}
-<section>
+<section class="mb-4">
   <h2>{{ _('Metadata') }}</h2>
   {% if metadata %}
   <h3>{{ _('Common') }}</h3>
@@ -51,7 +51,7 @@
 </section>
 {% endif %}
 {% if citations or user_citations %}
-<section>
+<section class="mb-4">
   <h2>{{ _('Citations') }}</h2>
   {% if citations %}
   <h3>{{ _('Global') }}</h3>
@@ -90,7 +90,7 @@
 </section>
 {% endif %}
 {% if current_user.is_authenticated %}
-<section>
+<section class="mb-4">
   <h2>{{ _('Add Citation') }}</h2>
   <form id="citation-form" action="{{ url_for('new_citation', post_id=post.id) }}" method="post">
     <div class="mb-3 d-flex gap-2">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -3,14 +3,14 @@
 {% block content %}
 <h1>{{ user.username }}</h1>
 <p>{{ user.bio }}</p>
-<section>
+<section class="mb-4">
   <h2>{{ _('Contribution Metrics') }}</h2>
   <ul class="list-group">
     <li class="list-group-item">{{ _('Posts') }}: {{ post_count }}</li>
     <li class="list-group-item">{{ _('Citations') }}: {{ citation_count }}</li>
   </ul>
 </section>
-<section>
+<section class="mb-4">
   <h2>{{ _('Recent Posts') }}</h2>
   <ul class="list-group">
   {% for p in posts %}
@@ -20,7 +20,7 @@
   {% endfor %}
   </ul>
 </section>
-<section>
+<section class="mb-4">
   <h2>{{ _('Edited Posts') }}</h2>
   <ul class="list-group">
   {% for p in edited_posts %}
@@ -31,7 +31,7 @@
   </ul>
 </section>
 {% if post_locations %}
-<section>
+<section class="mb-4">
   <h2>{{ _('Contribution Map') }}</h2>
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <div id="profile-map" style="height: 400px;"></div>
@@ -58,7 +58,7 @@
 </section>
 {% endif %}
 {% if current_user.is_authenticated and current_user.id == user.id %}
-<section>
+<section class="mb-4">
   <h2>{{ _('Edit Profile') }}</h2>
   <form method="post">
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- add reusable `mb-4` margin-bottom utility
- apply `mb-4` to all `<section>` elements in profile and post detail templates

## Testing
- `pytest` *(fails: tests/test_view_count.py::test_view_count_not_editable_via_metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db3e58d48329a4e694929a3a47f4