### PR TITLE
Redirect missing docs to new post form with prefilled fields

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -23,11 +23,11 @@
   {% endif %}
   <div class="mb-3">
     <label for="path">{{ _('Path (e.g., docs/start)') }}</label>
-    <input name="path" id="path" class="form-control" placeholder="{{ _('Path (e.g., docs/start)') }}" value="{{ post.path if post else '' }}">
+    <input name="path" id="path" class="form-control" placeholder="{{ _('Path (e.g., docs/start)') }}" value="{{ post.path if post else prefill_path or '' }}">
   </div>
   <div class="mb-3">
     <label for="language">{{ _('Language code') }}</label>
-    <input name="language" id="language" class="form-control" placeholder="{{ _('Language code') }}" value="{{ post.language if post else 'en' }}">
+    <input name="language" id="language" class="form-control" placeholder="{{ _('Language code') }}" value="{{ post.language if post else prefill_language or 'en' }}">
   </div>
   <div class="mb-3">
     <label for="tags">{{ _('Comma separated tags') }}</label>

--- a/tests/test_missing_doc_redirect.py
+++ b/tests/test_missing_doc_redirect.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db
+
+
+def test_missing_doc_redirect():
+    original_uri = app.config['SQLALCHEMY_DATABASE_URI']
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.engine.dispose()
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/docs/en/NonexistentPage')
+        assert resp.status_code == 302
+        loc = resp.headers['Location']
+        assert '/post/new' in loc
+        assert 'title=NonexistentPage' in loc
+        assert 'path=NonexistentPage' in loc
+        assert 'language=en' in loc
+        db.drop_all()
+    app.config['SQLALCHEMY_DATABASE_URI'] = original_uri
+    with app.app_context():
+        db.engine.dispose()


### PR DESCRIPTION
## Summary
- Redirect unknown document links to post creation page
- Prefill new post form with the missing page's title, path, and language
- Preserve view counts when editing posts and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0db0d5cd08329b24e275080774d82