### PR TITLE
Integrate EasyMDE editor and improve wiki linking

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import re
 import markdown
 from datetime import datetime, timezone
 from xml.etree.ElementTree import Element
+from urllib.parse import quote
 
 from flask import (Flask, render_template, redirect, url_for, request, flash,
                    abort, jsonify)
@@ -467,7 +468,8 @@ class WikiLinkInlineProcessor(InlineProcessor):
             target, text = label.split('|', 1)
         else:
             target = text = label
-        el = Element('a', {'href': f'{self.base_url}{target}'})
+        target_url = f"{self.base_url}{quote(target, safe='/#')}"
+        el = Element('a', {'href': target_url})
         el.text = text
         return el, m.start(0), m.end(0)
 
@@ -1254,8 +1256,10 @@ def document(language: str, doc_path: str):
 def markdown_preview():
     data = request.get_json() or {}
     text = data.get('text', '')
+    language = data.get('language', 'en')
+    base = url_for('document', language=language, doc_path='')
     escaped = escape(text)
-    html, _ = render_markdown(str(escaped))
+    html, _ = render_markdown(str(escaped), base)
     return {'html': str(Markup(html))}
 
 
@@ -1539,10 +1543,13 @@ def edit_post(post_id: int):
             post.latitude = None
             post.longitude = None
 
+        current_views = PostMetadata.query.filter_by(post_id=post.id, key='views').first()
         PostMetadata.query.filter_by(post_id=post.id).delete(synchronize_session=False)
 
         for key, value in meta_dict.items():
             db.session.add(PostMetadata(post=post, key=key, value=value))
+        if current_views:
+            db.session.add(PostMetadata(post=post, key='views', value=current_views.value))
 
         if user_metadata_json:
             try:

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -4,6 +4,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsoneditor@9/dist/jsoneditor.min.css" />
+<link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css" />
 <h1>{{ _('%(action)s Post', action=action) }}</h1>
 <form method="post">
   <div class="mb-3">
@@ -74,8 +75,9 @@
 <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jsoneditor@9/dist/jsoneditor.min.js"></script>
+<script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 <script>
-const bodyInput = document.querySelector('textarea[name="body"]');
+const easyMDE = new EasyMDE({ element: document.getElementById('body') });
 const previewEl = document.getElementById('preview');
 const formEl = document.querySelector('form');
 formEl.addEventListener('keydown', function (e) {
@@ -121,12 +123,16 @@ function updatePreview() {
   fetch('{{ url_for('markdown_preview') }}', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({text: bodyInput.value})
+    body: JSON.stringify({
+      text: easyMDE.value(),
+      language: document.getElementById('language').value
+    })
   }).then(r => r.json()).then(data => {
     previewEl.innerHTML = data.html || '';
   });
 }
-bodyInput.addEventListener('input', updatePreview);
+easyMDE.codemirror.on('change', updatePreview);
+document.getElementById('language').addEventListener('input', updatePreview);
 updatePreview();
 
 const map = L.map('map').setView([0, 0], 2);
@@ -184,7 +190,7 @@ document.getElementById('find-coordinates').addEventListener('click', function (
 {% if post %}
 <script>
 document.getElementById('suggest-citations').addEventListener('click', function () {
-  const body = document.querySelector('textarea[name="body"]').value;
+  const body = easyMDE.value();
   const lines = body.split('\n').filter(l => l.trim());
   const container = document.getElementById('citation-results');
   container.innerHTML = '';

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app import render_markdown
+from app import app, render_markdown
 
 
 def test_render_markdown_and_wikilink():
@@ -10,3 +12,20 @@ def test_render_markdown_and_wikilink():
     assert '<strong>bold</strong>' in html
     assert '<a href="/docs/Page">link</a>' in html
     assert toc == ''
+
+
+def test_render_markdown_wikilink_spaces():
+    html, _ = render_markdown('[[My Page]]')
+    assert '<a href="/docs/My%20Page">My Page</a>' in html
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_markdown_preview_language(client):
+    resp = client.post('/markdown/preview', json={'text': '[[Page]]', 'language': 'es'})
+    assert resp.get_json()['html'] == '<p><a href="/docs/es/Page">Page</a></p>'


### PR DESCRIPTION
## Summary
- Replace plain textarea with EasyMDE markdown editor and language-aware preview
- Encode wiki links for safe page URLs and ensure preview uses correct language
- Preserve view count metadata when editing posts and extend tests for wiki links and preview

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0da3a9f18832982713207117723cf