### PR TITLE
Add reverse geocoding and citation context support

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,6 +246,35 @@ def geocode_address(address: str) -> tuple[float, float] | None:
     return coords
 
 
+def reverse_geocode_coords(lat: float, lon: float) -> str | None:
+    """Return human-readable address for coordinates using Nominatim.
+
+    Results are cached in ``geocode_cache`` keyed by ``"rev:lat,lon"``. Cache
+    failures are ignored so the reverse geocoding still proceeds normally.
+    """
+    key = f"rev:{lat},{lon}"
+    if geocode_cache:
+        try:
+            cached = geocode_cache.get(key)
+            if cached:
+                return cached
+        except Exception:
+            pass
+    try:
+        location = geolocator.reverse((lat, lon))
+    except Exception:
+        return None
+    if not location:
+        return None
+    address = location.address
+    if geocode_cache:
+        try:
+            geocode_cache.setex(key, GEOCODE_CACHE_TTL, address)
+        except Exception:
+            pass
+    return address
+
+
 COORD_OUT_OF_RANGE_MSG = 'Coordinates out of range'
 
 
@@ -319,8 +348,12 @@ def format_metadata_value(value):
             except (TypeError, ValueError):
                 return Markup(escape(json.dumps(value)))
             if -90 <= lat_f <= 90 and -180 <= lon_f <= 180:
+                address = reverse_geocode_coords(lat_f, lon_f)
+                label = f"{lat_f}, {lon_f}"
+                if address:
+                    label += f" ({escape(address)})"
                 return Markup(
-                    f'<a href="{map_link(lat_f, lon_f)}">{lat_f}, {lon_f}</a>'
+                    f'<a href="{map_link(lat_f, lon_f)}">{label}</a>'
                 )
             return Markup(_(COORD_OUT_OF_RANGE_MSG))
         features = parse_geodata(value)
@@ -726,6 +759,7 @@ class PostCitation(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     citation_part = db.Column(db.JSON, nullable=False)
     citation_text = db.Column(db.Text, nullable=False)
+    context = db.Column(db.Text)
     doi = db.Column(db.String, nullable=True)
     bibtex_raw = db.Column(db.Text, nullable=False)
     bibtex_fields = db.Column(db.JSON, nullable=False)
@@ -743,6 +777,7 @@ class UserPostCitation(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     citation_part = db.Column(db.JSON, nullable=False)
     citation_text = db.Column(db.Text, nullable=False)
+    context = db.Column(db.Text)
     doi = db.Column(db.String, nullable=True)
     bibtex_raw = db.Column(db.Text, nullable=False)
     bibtex_fields = db.Column(db.JSON, nullable=False)
@@ -1101,6 +1136,9 @@ def post_detail(post_id: int):
     views = increment_view_count(post)
     post_meta = {m.key: m.value for m in post.metadata}
     location, warning = extract_location(post_meta)
+    location_name = None
+    if location:
+        location_name = reverse_geocode_coords(location['lat'], location['lon'])
     geodata = extract_geodata(post_meta)
     if warning:
         flash(_(warning))
@@ -1132,6 +1170,7 @@ def post_detail(post_id: int):
         toc=toc,
         metadata=post_meta,
         location=location,
+        location_name=location_name,
         geodata=geodata,
         user_metadata=user_meta,
         citations=citations,
@@ -1326,6 +1365,7 @@ def fetch_citation():
 def new_citation(post_id: int):
     post = Post.query.get_or_404(post_id)
     text = request.form.get('citation_text', '').strip()
+    context = request.form.get('citation_context', '').strip()
     if not text:
         flash(_('Citation text is required.'))
         return redirect(url_for('post_detail', post_id=post.id))
@@ -1361,6 +1401,7 @@ def new_citation(post_id: int):
             user=current_user,
             citation_part=entry,
             citation_text=text,
+            context=context,
             doi=doi,
             bibtex_raw=text,
             bibtex_fields=entry,
@@ -1371,6 +1412,7 @@ def new_citation(post_id: int):
             user=current_user,
             citation_part=entry,
             citation_text=text,
+            context=context,
             doi=doi,
             bibtex_raw=text,
             bibtex_fields=entry,
@@ -1392,6 +1434,7 @@ def edit_citation(post_id: int, cid: int):
         return redirect(url_for('post_detail', post_id=post.id))
     if request.method == 'POST':
         text = request.form.get('citation_text', '').strip()
+        context = request.form.get('citation_context', '').strip()
         if not text:
             flash(_('Citation text is required.'))
             return redirect(url_for('edit_citation', post_id=post.id, cid=cid))
@@ -1439,6 +1482,7 @@ def edit_citation(post_id: int, cid: int):
                 return redirect(url_for('edit_citation', post_id=post.id, cid=cid))
         citation.citation_part = entry
         citation.citation_text = text
+        citation.context = context
         citation.doi = doi
         citation.bibtex_raw = text
         citation.bibtex_fields = entry
@@ -1539,7 +1583,10 @@ def edit_post(post_id: int):
             post.latitude = None
             post.longitude = None
 
-        PostMetadata.query.filter_by(post_id=post.id).delete(synchronize_session=False)
+        PostMetadata.query.filter(
+            PostMetadata.post_id == post.id,
+            PostMetadata.key != 'views',
+        ).delete(synchronize_session=False)
 
         for key, value in meta_dict.items():
             db.session.add(PostMetadata(post=post, key=key, value=value))

--- a/templates/citation_form.html
+++ b/templates/citation_form.html
@@ -10,6 +10,9 @@
     <textarea name="citation_text" placeholder="{{ _('Citation text') }}" rows="5" cols="50" class="form-control">{{ citation.citation_text if citation else '' }}</textarea>
   </div>
   <div class="mb-3">
+    <input type="text" name="citation_context" placeholder="{{ _('Citation context') }}" value="{{ citation.context if citation else '' }}" class="form-control" />
+  </div>
+  <div class="mb-3">
     <button type="submit" class="btn btn-primary">{{ action }}</button>
   </div>
 </form>

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -29,6 +29,9 @@
 {% if metadata or user_metadata %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
+  {% if location_name %}
+  <p><strong>{{ _('Location') }}:</strong> {{ location_name }}</p>
+  {% endif %}
   {% if metadata %}
   <h3>{{ _('Common') }}</h3>
   <ul class="list-group">
@@ -58,6 +61,7 @@
   <ul class="list-group">
     {% for c in citations %}
       <li class="list-group-item text-break">
+        {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
         {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
@@ -76,6 +80,7 @@
   <ul class="list-group">
     {% for c in user_citations %}
       <li class="list-group-item text-break">
+        {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
         {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
         {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
@@ -102,6 +107,9 @@
     </div>
     <div class="mb-3">
       <textarea id="citation-text" name="citation_text" placeholder="{{ _('Citation text') }}" rows="4" cols="50" class="form-control"></textarea>
+    </div>
+    <div class="mb-3">
+      <input type="text" id="citation-context" name="citation_context" placeholder="{{ _('Citation context') }}" class="form-control" />
     </div>
     <div class="mb-3">
       <button type="submit" class="btn btn-primary">{{ _('Add Citation') }}</button>

--- a/tests/test_citation_context.py
+++ b/tests/test_citation_context.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_citation_context_display(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        post_id = post.id
+    resp = client.post(
+        f'/post/{post_id}/citation/new',
+        data={
+            'citation_text': '@article{a,title={t}}',
+            'citation_context': 'Intro section',
+        },
+    )
+    assert resp.status_code == 302
+    resp = client.get(f'/post/{post_id}')
+    assert b'Intro section' in resp.data
+    with app.app_context():
+        cit = PostCitation.query.filter_by(post_id=post_id).first()
+        assert cit.context == 'Intro section'

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,9 +1,10 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app
 from app import (
     format_metadata_value,
     extract_location,
@@ -12,7 +13,8 @@ from app import (
 )
 
 
-def test_format_metadata_value_valid():
+def test_format_metadata_value_valid(monkeypatch):
+    monkeypatch.setattr(app, 'reverse_geocode_coords', lambda lat, lon: None)
     value = {'lat': 10, 'lon': 20}
     result = format_metadata_value(value)
     assert 'href' in result

--- a/tests/test_reverse_geocode.py
+++ b/tests/test_reverse_geocode.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app as app_module
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_post_shows_reverse_geocode(client, monkeypatch):
+    monkeypatch.setattr(app_module, 'reverse_geocode_coords', lambda lat, lon: 'Test Place')
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '{"loc":{"lat":1,"lon":2}}',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        post_id = post.id
+    resp = client.get(f'/post/{post_id}')
+    assert b'Test Place' in resp.data


### PR DESCRIPTION
## Summary
- show human-readable locations by reverse geocoding post latitude/longitude metadata
- allow adding a context description to citations and display it
- cover new behaviour with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0da7a8678832991c9ca347353a70a