### PR TITLE
Use Spacetime as default site name

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% block title %}{{ get_setting('site_title', _('Wiki Board')) }}{% endblock %}</title>
+  <title>{% block title %}{{ get_setting('site_title', _('Spacetime')) }}{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
@@ -11,7 +11,7 @@
 <body>
 <nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">{{ get_setting('site_title', _('Home')) }}</a>
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ get_setting('site_title', _('Spacetime')) }}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -71,7 +71,7 @@
 </div>
 <footer class="footer mt-5 py-3">
   <div class="container text-center">
-    <p class="mb-1">&copy; {{ get_setting('site_title', _('Wiki Board')) }}</p>
+    <p class="mb-1">&copy; {{ get_setting('site_title', _('Spacetime')) }}</p>
     <a href="{{ url_for('index') }}">{{ _('Home') }}</a>
     |
     <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a>

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -84,9 +84,9 @@ msgstr "Editar"
 msgid "Post \"%(title)s\" was updated."
 msgstr "La publicación \"%(title)s\" fue actualizada."
 
-#: templates/base.html:5
-msgid "Wiki Board"
-msgstr "Tablón Wiki"
+#: templates/base.html:6
+msgid "Spacetime"
+msgstr "Spacetime"
 
 #: templates/base.html:11
 msgid "Home"


### PR DESCRIPTION
## Summary
- Replace default "Wiki Board" site name with "Spacetime" in base template
- Update Spanish translation catalog for new site name

## Testing
- `pytest -q` *(fails: tests/test_view_count.py::test_view_count_not_editable_via_metadata - sqlalchemy.exc.IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ddeda1c08329ad4501f4a89f83d5