### PR TITLE
Render lat/lon metadata on map

### DIFF
--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -58,3 +58,11 @@ def test_extract_geodata_from_list():
     geoms = extract_geodata(meta)
     assert len(geoms) == 2
     assert all(g['geometry']['type'] == 'Point' for g in geoms)
+
+
+def test_extract_geodata_from_lat_lon_fields():
+    meta = {'lat': 10, 'lon': 20}
+    geoms = extract_geodata(meta)
+    assert len(geoms) == 1
+    assert geoms[0]['geometry']['type'] == 'Point'
+    assert geoms[0]['geometry']['coordinates'] == [20.0, 10.0]


### PR DESCRIPTION
## Summary
- include top-level `lat`/`lon` values in map rendering
- avoid duplicating existing `views` metadata when editing posts
- test geodata extraction from `lat`/`lon` fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0de9982ac8329bc740168db1d90c2