### PR TITLE
Add global AJAX spinner

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -198,6 +198,19 @@ pre {
   }
 }
 
+#spinner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 2000;
+}
+
 .tag-card {
   border: 1px solid var(--border-color);
   background-color: var(--nav-bg-color);

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,6 +59,30 @@
     </div>
   </div>
 </nav>
+<div id="spinner-overlay">
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">{{ _('Loading...') }}</span>
+  </div>
+</div>
+<script>
+  (function () {
+    const spinnerOverlay = document.getElementById('spinner-overlay');
+    function showSpinner() { spinnerOverlay.style.display = 'flex'; }
+    function hideSpinner() { spinnerOverlay.style.display = 'none'; }
+    let spinnerCount = 0;
+    const originalFetch = window.fetch;
+    window.fetch = function (...args) {
+      spinnerCount++;
+      showSpinner();
+      return originalFetch(...args).finally(() => {
+        spinnerCount--;
+        if (spinnerCount === 0) hideSpinner();
+      });
+    };
+    window.showSpinner = showSpinner;
+    window.hideSpinner = hideSpinner;
+  })();
+</script>
 <div class="container mt-4">
 {% with messages = get_flashed_messages() %}
   {% if messages %}


### PR DESCRIPTION
## Summary
- add a global spinner overlay and intercept fetch to display it during AJAX requests
- style spinner overlay for centered display and high z-index

## Testing
- `pytest -q` *(fails: sqlalchemy.exc.IntegrityError: UNIQUE constraint failed: post_metadata.post_id, post_metadata.key)*

------
https://chatgpt.com/codex/tasks/task_e_68a0df03ecbc8329bfaf233aee936a01