### PR TITLE
Skip empty TOC rendering for markdown pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -543,6 +543,8 @@ def render_markdown(text: str, base_url: str = '/docs/', with_toc: bool = False)
     if with_toc:
         md = markdown.Markdown(extensions=extensions + ['toc'])
         html = md.convert(text or '')
+        if not getattr(md, 'toc_tokens', None):
+            return html, ''
         return html, md.toc
     html = markdown.markdown(text or '', extensions=extensions)
     return html, ''
@@ -1639,8 +1641,10 @@ def edit_post(post_id: int):
 
         for key, value in meta_dict.items():
             db.session.add(PostMetadata(post=post, key=key, value=value))
+
+        # Preserve existing view counts without creating duplicate metadata entries
         if current_views:
-            db.session.add(PostMetadata(post=post, key='views', value=current_views.value))
+            db.session.add(current_views)
 
 
         if user_metadata_json:

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -19,6 +19,18 @@ def test_render_markdown_wikilink_spaces():
     assert '<a href="/docs/My%20Page">My Page</a>' in html
 
 
+def test_render_markdown_with_toc_no_headings():
+    html, toc = render_markdown('Just text', with_toc=True)
+    assert '<p>Just text</p>' in html
+    assert toc == ''
+
+
+def test_render_markdown_with_toc_headings():
+    html, toc = render_markdown('# Heading', with_toc=True)
+    assert '<h1 id="heading">Heading</h1>' in html
+    assert '<a href="#heading">Heading</a>' in toc
+
+
 @pytest.fixture
 def client():
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- Avoid returning a TOC when markdown has no headings so empty navigation isn't displayed
- Preserve existing view count metadata when editing posts
- Add tests for TOC generation with and without headings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0df677dac8329b1f71fafe389f7a4