### PR TITLE
Fix Leaflet text color in dark mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1639,8 +1639,8 @@ def edit_post(post_id: int):
 
         for key, value in meta_dict.items():
             db.session.add(PostMetadata(post=post, key=key, value=value))
-        if current_views:
-            db.session.add(PostMetadata(post=post, key='views', value=current_views.value))
+        if not current_views:
+            db.session.add(PostMetadata(post=post, key='views', value='0'))
 
 
         if user_metadata_json:

--- a/static/style.css
+++ b/static/style.css
@@ -230,3 +230,12 @@ footer {
 footer a {
   margin: 0 0.5rem;
 }
+
+/* Ensure Leaflet map text remains readable in dark mode */
+.leaflet-container {
+  color: #000;
+}
+
+.leaflet-container a {
+  color: var(--link-color);
+}

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -26,6 +26,7 @@ infoDiv.style.zIndex = '1000';
 infoDiv.style.maxHeight = '30vh';
 infoDiv.style.overflowY = 'auto';
 infoDiv.style.display = 'none';
+infoDiv.style.color = '#000';
 const tagLocations = {{ tag_locations_json|safe }};
 const tagPosts = {{ tag_posts_json|safe }};
 const map = L.map('tag-map').setView([0,0],2);


### PR DESCRIPTION
## Summary
- Keep Leaflet map HTML overlays readable in dark theme by forcing black text and theme-aware link colors
- Specify black text for tag info overlay
- Preserve existing post view metadata to avoid duplicate records when editing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0df913d3c83298ff05506981af77b