### PR TITLE
Align path-based post view with ID-based route

### DIFF
--- a/tests/test_reverse_geocode.py
+++ b/tests/test_reverse_geocode.py
@@ -44,3 +44,22 @@ def test_post_shows_reverse_geocode(client, monkeypatch):
         post_id = post.id
     resp = client.get(f'/post/{post_id}')
     assert b'Test Place' in resp.data
+
+
+def test_doc_path_shows_reverse_geocode(client, monkeypatch):
+    monkeypatch.setattr(app_module, 'reverse_geocode_coords', lambda lat, lon: 'Test Place')
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '{"loc":{"lat":1,"lon":2}}',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    resp = client.get('/post/en/p')
+    assert b'Test Place' in resp.data


### PR DESCRIPTION
## Summary
- Allow viewing posts via `/post/<language>/<path>` as well as `/docs/<language>/<path>`
- Display location, geodata, TOC and other metadata for path-based posts, matching `/post/<id>` behavior
- Test that path-based URLs show reverse geocoded location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e10bdf288329b80929b509b6d3c7