### PR TITLE
Open external links in a new tab

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -167,12 +167,14 @@
           img.style.display = 'none';
         }
         const cont = document.getElementById('ogContinue');
-        cont.onclick = () => { window.location.href = url; };
-        cont.href = url;
         const modal = new bootstrap.Modal(document.getElementById('ogModal'));
+        cont.onclick = () => { window.open(url, '_blank'); modal.hide(); };
+        cont.href = url;
+        cont.target = '_blank';
+        cont.rel = 'noopener noreferrer';
         modal.show();
       })
-      .catch(() => { window.location.href = url; });
+      .catch(() => { window.open(url, '_blank'); });
   });
 </script>
 <script>


### PR DESCRIPTION
## Summary
- Ensure external links open in a new tab by changing modal continue action to `window.open`.
- Default external link handling now always opens new windows, even when metadata fetch fails.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1be8bb88329b66df02cf40d1b1f