### PR TITLE
Add configurable RSS feed for posts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -99,6 +99,10 @@
     <a href="{{ url_for('index') }}">{{ _('Home') }}</a>
     |
     <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a>
+    {% if get_setting('rss_enabled', 'false').lower() in ['true', '1', 'yes', 'on'] %}
+    |
+    <a href="{{ url_for('rss_feed') }}">RSS</a>
+    {% endif %}
   </div>
 </footer>
 <div class="modal fade" id="ogModal" tabindex="-1" aria-hidden="true">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,6 +15,14 @@
       <label for="timezone" class="form-label">{{ _('Timezone') }}</label>
       <input type="text" id="timezone" name="timezone" class="form-control" value="{{ timezone }}">
     </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="rss_enabled" name="rss_enabled" {% if rss_enabled %}checked{% endif %}>
+      <label class="form-check-label" for="rss_enabled">{{ _('Enable RSS feed') }}</label>
+    </div>
+    <div class="mb-3">
+      <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
+      <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
+    </div>
     <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
   </form>
 {% endblock %}

--- a/tests/test_rss_feed.py
+++ b/tests/test_rss_feed.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Setting, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def _create_post():
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        post = Post(title='Hello', body='World', path='hello', language='en', author=user)
+        db.session.add(post)
+        db.session.commit()
+        rev = Revision(
+            post_id=post.id,
+            user_id=user.id,
+            title=post.title,
+            body=post.body,
+            path=post.path,
+            language=post.language,
+        )
+        db.session.add(rev)
+        db.session.commit()
+
+
+def test_rss_feed_disabled(client):
+    _create_post()
+    resp = client.get('/rss.xml')
+    assert resp.status_code == 404
+
+
+def test_rss_feed_enabled(client):
+    with app.app_context():
+        db.session.add(Setting(key='rss_enabled', value='true'))
+        db.session.commit()
+    _create_post()
+    resp = client.get('/rss.xml')
+    assert resp.status_code == 200
+    assert b'Hello' in resp.data


### PR DESCRIPTION
## Summary
- add `/rss.xml` endpoint serving an RSS feed of recent posts
- allow admins to enable RSS and set item limit in settings
- show RSS link in footer when feed is enabled
- test RSS feed accessibility based on setting

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e26141b88329b0536e942a467040