### PR TITLE
Show spinner when adding citation by URL

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -163,12 +163,14 @@
       const url = document.getElementById('citation-url').value;
       document.getElementById('citation-text').value = url;
       document.getElementById('citation-part').value = '';
-      document.getElementById('citation-form').submit();
+      document.getElementById('citation-form').requestSubmit();
   });
   document.getElementById('citation-form').addEventListener('submit', function(e) {
       if (!confirm('{{ _('Are you sure?') }}')) {
           e.preventDefault();
+          return;
       }
+      showSpinner();
   });
   </script>
 </section>


### PR DESCRIPTION
## Summary
- show spinner when submitting a citation by URL
- ensure citation form submissions trigger spinner and confirmation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e2b92e0c832990964b5f87dc1df2