### PR TITLE
Fix All Posts button showing home page

### DIFF
--- a/app.py
+++ b/app.py
@@ -869,6 +869,12 @@ def load_user(user_id: str):
     return User.query.get(int(user_id))
 
 
+@app.route('/posts')
+def all_posts():
+    posts = Post.query.order_by(Post.id.desc()).all()
+    return render_template('index.html', posts=posts)
+
+
 @app.route('/')
 def index():
     home_path = get_setting('home_page_path', '').strip()
@@ -877,8 +883,7 @@ def index():
         post = Post.query.filter_by(language=language, path=home_path).first()
         if post:
             return redirect(url_for('document', language=language, doc_path=home_path))
-    posts = Post.query.order_by(Post.id.desc()).all()
-    return render_template('index.html', posts=posts)
+    return all_posts()
 
 
 @app.route('/recent')

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}" aria-label="{{ _('All Posts') }}" title="{{ _('All Posts') }}"><i class="bi bi-card-list" aria-hidden="true"></i><span class="visually-hidden">{{ _('All Posts') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('all_posts') }}" aria-label="{{ _('All Posts') }}" title="{{ _('All Posts') }}"><i class="bi bi-card-list" aria-hidden="true"></i><span class="visually-hidden">{{ _('All Posts') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('tag_list') }}" aria-label="{{ _('Tags') }}" title="{{ _('Tags') }}"><i class="bi bi-tags" aria-hidden="true"></i><span class="visually-hidden">{{ _('Tags') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('recent_changes') }}" aria-label="{{ _('Recent changes') }}" title="{{ _('Recent changes') }}"><i class="bi bi-clock-history" aria-hidden="true"></i><span class="visually-hidden">{{ _('Recent changes') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}"><i class="bi bi-bar-chart" aria-hidden="true"></i><span class="visually-hidden">{{ _('Citation Stats') }}</span></a></li>

--- a/tests/test_all_posts_route.py
+++ b/tests/test_all_posts_route.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Setting
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_all_posts_route_returns_list(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        post = Post(title='Home', body='Content', path='home', language='en', author=user)
+        other = Post(title='Other', body='Content', path='other', language='en', author=user)
+        db.session.add_all([post, other])
+        db.session.add(Setting(key='home_page_path', value='home'))
+        db.session.commit()
+
+    resp = client.get('/posts')
+    assert resp.status_code == 200
+    assert b'Home' in resp.data
+    assert b'Other' in resp.data
+    assert b'href="/posts"' in resp.data


### PR DESCRIPTION
## Summary
- Add dedicated `/posts` route to always list posts
- Point navbar "All Posts" button to new route
- Cover the route with a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e3656454832987f7297aa0aac88b