### PR TITLE
Add sitemap.xml endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -932,6 +932,27 @@ def rss_feed():
     return Response(xml, mimetype='application/rss+xml')
 
 
+@app.route('/sitemap.xml')
+def sitemap():
+    """Generate a basic XML sitemap of all posts."""
+    posts = Post.query.order_by(Post.id.desc()).all()
+    root = Element('urlset', xmlns='http://www.sitemaps.org/schemas/sitemap/0.9')
+    for post in posts:
+        url_el = SubElement(root, 'url')
+        SubElement(url_el, 'loc').text = url_for(
+            'document', language=post.language, doc_path=post.path, _external=True
+        )
+        rev = (
+            Revision.query.filter_by(post_id=post.id)
+            .order_by(Revision.created_at.desc())
+            .first()
+        )
+        if rev:
+            SubElement(url_el, 'lastmod').text = rev.created_at.date().isoformat()
+    xml = tostring(root, encoding='utf-8')
+    return Response(xml, mimetype='application/xml')
+
+
 @app.route('/recent')
 def recent_changes():
     revisions = (

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def _create_post():
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        post = Post(title='Hello', body='World', path='hello', language='en', author=user)
+        db.session.add(post)
+        db.session.commit()
+        rev = Revision(
+            post_id=post.id,
+            user_id=user.id,
+            title=post.title,
+            body=post.body,
+            path=post.path,
+            language=post.language,
+        )
+        db.session.add(rev)
+        db.session.commit()
+
+
+def test_sitemap(client):
+    _create_post()
+    resp = client.get('/sitemap.xml')
+    assert resp.status_code == 200
+    assert b'http://localhost/docs/en/hello' in resp.data


### PR DESCRIPTION
## Summary
- add `/sitemap.xml` endpoint generating sitemap from stored posts
- cover new endpoint with tests verifying generated URLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e3c2bd00832997969f08156d1cef