### PR TITLE
Use radio buttons for language selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1236,6 +1236,7 @@ def create_post():
         request_id=req_id,
         lat=None,
         lon=None,
+        languages=app.config['LANGUAGES'],
     )
 
 
@@ -1765,7 +1766,8 @@ def edit_post(post_id: int):
     user_meta_dict = {m.key: m.value for m in user_entries}
     user_meta = json.dumps(user_meta_dict) if user_meta_dict else ''
     return render_template('post_form.html', action=_('Edit'), post=post, tags=tags_str,
-                           metadata=post_meta, user_metadata=user_meta, lat=lat, lon=lon)
+                           metadata=post_meta, user_metadata=user_meta, lat=lat, lon=lon,
+                           languages=app.config['LANGUAGES'])
 
 
 @app.route('/post/<int:post_id>/history')

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -26,9 +26,15 @@
     <label for="path">{{ _('Path (e.g., docs/start)') }}</label>
     <input name="path" id="path" class="form-control" placeholder="{{ _('Path (e.g., docs/start)') }}" value="{{ post.path if post else prefill_path or '' }}">
   </div>
+  {% set selected_language = post.language if post else prefill_language or 'en' %}
   <div class="mb-3">
-    <label for="language">{{ _('Language code') }}</label>
-    <input name="language" id="language" class="form-control" placeholder="{{ _('Language code') }}" value="{{ post.language if post else prefill_language or 'en' }}">
+    <label>{{ _('Language code') }}</label>
+    {% for lang in languages %}
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="language" id="language-{{ lang }}" value="{{ lang }}" {% if lang == selected_language %}checked{% endif %}>
+      <label class="form-check-label" for="language-{{ lang }}">{{ lang }}</label>
+    </div>
+    {% endfor %}
   </div>
   <div class="mb-3">
     <label for="tags">{{ _('Comma separated tags') }}</label>
@@ -127,14 +133,16 @@ function updatePreview() {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({
       text: easyMDE.value(),
-      language: document.getElementById('language').value
+      language: document.querySelector('input[name="language"]:checked').value
     })
   }).then(r => r.json()).then(data => {
     previewEl.innerHTML = data.html || '';
   });
 }
 easyMDE.codemirror.on('change', updatePreview);
-document.getElementById('language').addEventListener('input', updatePreview);
+document.querySelectorAll('input[name="language"]').forEach(el => {
+  el.addEventListener('change', updatePreview);
+});
 updatePreview();
 
 const map = L.map('map').setView([0, 0], 2);


### PR DESCRIPTION
## Summary
- render language choices as radio buttons based on `LANGUAGES` from the environment
- provide available languages to post form templates and update preview script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4c2f2a483299c562d55aeac0e42