### PR TITLE
Render coordinates inline with location on posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1271,6 +1271,10 @@ def post_detail(post_id: int):
     if location:
         location_name = reverse_geocode_coords(location['lat'], location['lon'])
     geodata = extract_geodata(post_meta)
+    meta_no_coords = post_meta.copy()
+    if location:
+        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng'):
+            meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
     user_meta = {}
@@ -1299,7 +1303,7 @@ def post_detail(post_id: int):
         post=post,
         html_body=html_body,
         toc=toc,
-        metadata=post_meta,
+        metadata=meta_no_coords,
         location=location,
         location_name=location_name,
         geodata=geodata,
@@ -1397,6 +1401,10 @@ def document(language: str, doc_path: str):
     if location:
         location_name = reverse_geocode_coords(location['lat'], location['lon'])
     geodata = extract_geodata(post_meta)
+    meta_no_coords = post_meta.copy()
+    if location:
+        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng'):
+            meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
     user_meta = {}
@@ -1429,7 +1437,7 @@ def document(language: str, doc_path: str):
         html_body=html_body,
         toc=toc,
         translations=translations,
-        metadata=post_meta,
+        metadata=meta_no_coords,
         location=location,
         location_name=location_name,
         geodata=geodata,

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -42,11 +42,17 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
-{% if metadata or user_metadata %}
+{% if metadata or user_metadata or location or geodata %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
-  {% if location_name %}
-  <p><strong>{{ _('Location') }}:</strong> {{ location_name }}</p>
+  {% if location %}
+  <p>
+    <strong>{{ _('Location') }}:</strong>
+    {% if location_name %}
+      {{ location_name }}
+    {% endif %}
+    <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
+  </p>
   {% endif %}
   {% if metadata %}
   <h3>{{ _('Common') }}</h3>
@@ -55,9 +61,9 @@
       <li class="list-group-item"><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
     {% endfor %}
   </ul>
+  {% endif %}
   {% if geodata %}
   <div id="map"></div>
-  {% endif %}
   {% endif %}
   {% if user_metadata %}
   <h3>{{ _('Your Metadata') }}</h3>

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app
+from app import app as flask_app, db, User, Post, PostMetadata
+
+
+@pytest.fixture
+def client(monkeypatch):
+    flask_app.config['TESTING'] = True
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    monkeypatch.setattr(app, 'reverse_geocode_coords', lambda lat, lon: None)
+    with flask_app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        post = Post(title='Post', body='body', path='p', language='en', author=user)
+        db.session.add_all([user, post])
+        db.session.flush()
+        db.session.add_all([
+            PostMetadata(post=post, key='lat', value='10.0'),
+            PostMetadata(post=post, key='lon', value='20.0'),
+        ])
+        db.session.commit()
+    with flask_app.test_client() as client:
+        yield client
+    with flask_app.app_context():
+        db.drop_all()
+
+
+def test_coordinates_not_list_items(client):
+    resp = client.get('/docs/en/p')
+    data = resp.get_data(as_text=True)
+    assert '<strong>lat:' not in data
+    assert '<strong>lon:' not in data
+    assert '(10.0, 20.0)' in data


### PR DESCRIPTION
## Summary
- Display location coordinates inline rather than as separate list items
- Exclude lat/lon from generic metadata before rendering
- Test that coordinates no longer appear as list-group items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e64ad1188329960311b5cd339db1