### PR TITLE
Enable category filtering on posts page

### DIFF
--- a/app.py
+++ b/app.py
@@ -779,6 +779,11 @@ def get_setting(key: str, default: str = '') -> str:
     return setting.value if setting else default
 
 
+def get_category_tags() -> list[str]:
+    """Return list of category tag names from settings."""
+    return [t.strip() for t in get_setting('post_categories', '').split(',') if t.strip()]
+
+
 @app.context_processor
 def inject_settings():
     return {'get_setting': get_setting}
@@ -880,8 +885,15 @@ def load_user(user_id: str):
 
 @app.route('/posts')
 def all_posts():
-    posts = Post.query.order_by(Post.id.desc()).all()
-    return render_template('index.html', posts=posts)
+    tag_name = request.args.get('tag', '').strip()
+    tag = None
+    if tag_name:
+        tag = Tag.query.filter_by(name=tag_name).first_or_404()
+        posts = tag.posts
+    else:
+        posts = Post.query.order_by(Post.id.desc()).all()
+    categories = get_category_tags()
+    return render_template('index.html', posts=posts, tag=tag, categories=categories)
 
 
 @app.route('/')
@@ -1887,6 +1899,7 @@ def settings():
     timezone_value = get_setting('timezone', 'UTC')
     rss_enabled_val = get_setting('rss_enabled', 'false')
     rss_limit = get_setting('rss_limit', '20')
+    category_tags = get_setting('post_categories', '')
     if request.method == 'POST':
 
         title = request.form.get('site_title', title).strip()
@@ -1894,6 +1907,7 @@ def settings():
         timezone_value = request.form.get('timezone', timezone_value).strip() or 'UTC'
         rss_enabled_val = 'rss_enabled' in request.form
         rss_limit = request.form.get('rss_limit', rss_limit).strip() or '20'
+        category_tags = request.form.get('post_categories', category_tags).strip()
 
         title_setting = Setting.query.filter_by(key='site_title').first()
         if title_setting:
@@ -1931,6 +1945,12 @@ def settings():
         else:
             db.session.add(Setting(key='rss_limit', value=rss_limit))
 
+        cat_setting = Setting.query.filter_by(key='post_categories').first()
+        if cat_setting:
+            cat_setting.value = category_tags
+        else:
+            db.session.add(Setting(key='post_categories', value=category_tags))
+
         db.session.commit()
         flash(_('Settings updated.'))
         return redirect(url_for('settings'))
@@ -1941,6 +1961,7 @@ def settings():
         timezone=timezone_value,
         rss_enabled=rss_enabled_val.lower() in ['true', '1', 'yes', 'on'],
         rss_limit=rss_limit,
+        post_categories=category_tags,
     )
 
 
@@ -2006,7 +2027,8 @@ def tag_list():
 @app.route('/tag/<string:name>')
 def tag_filter(name: str):
     tag = Tag.query.filter_by(name=name).first_or_404()
-    return render_template('index.html', posts=tag.posts, tag=tag)
+    categories = get_category_tags()
+    return render_template('index.html', posts=tag.posts, tag=tag, categories=categories)
 
 
 @app.route('/search')

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,13 @@
 {% if current_user.is_authenticated %}
   <p><a href="{{ url_for('create_post') }}" class="btn btn-primary">{{ _('New Post') }}</a></p>
 {% endif %}
+{% if categories %}
+  <div class="mb-3">
+    {% for name in categories %}
+      <a class="btn btn-outline-secondary btn-sm{% if tag and tag.name == name %} active{% endif %}" href="{{ url_for('all_posts', tag=name) }}">{{ name }}</a>
+    {% endfor %}
+  </div>
+{% endif %}
 <div id="post-list" class="row row-cols-1 row-cols-md-2 g-4">
   {% for post in posts %}
     <div class="col">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,6 +23,10 @@
       <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
       <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
     </div>
+    <div class="mb-3">
+      <label for="post_categories" class="form-label">{{ _('Category tags (comma separated)') }}</label>
+      <input type="text" id="post_categories" name="post_categories" class="form-control" value="{{ post_categories }}">
+    </div>
     <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
   </form>
 {% endblock %}

--- a/tests/test_post_categories.py
+++ b/tests/test_post_categories.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Tag, Setting
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_posts_category_filter(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        news = Tag(name='news')
+        tech = Tag(name='tech')
+        misc = Tag(name='misc')
+        db.session.add_all([news, tech, misc])
+        p1 = Post(title='News Post', body='b', path='news', language='en', author=user, tags=[news])
+        p2 = Post(title='Tech Post', body='b', path='tech', language='en', author=user, tags=[tech])
+        p3 = Post(title='Misc Post', body='b', path='misc', language='en', author=user, tags=[misc])
+        db.session.add_all([p1, p2, p3])
+        db.session.add(Setting(key='post_categories', value='news, tech'))
+        db.session.commit()
+
+    resp = client.get('/posts')
+    assert resp.status_code == 200
+    assert b'?tag=news' in resp.data
+    assert b'?tag=tech' in resp.data
+
+    resp = client.get('/posts', query_string={'tag': 'news'})
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+    assert b'Misc Post' not in resp.data
+


### PR DESCRIPTION
## Summary
- allow specifying category tags in settings
- filter and display posts by categories via `/posts`
- add tests for category tag filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e72878508329b25cee73c3276bfa