### PR TITLE
feat: support multilingual category tags

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,8 @@
 {% endif %}
 {% if categories %}
   <div class="mb-3">
-    {% for name in categories %}
-      <a class="btn btn-outline-secondary btn-sm{% if tag and tag.name == name %} active{% endif %}" href="{{ url_for('all_posts', tag=name) }}">{{ name }}</a>
+    {% for slug, label in categories %}
+      <a class="btn btn-outline-secondary btn-sm{% if tag and tag.name == slug %} active{% endif %}" href="{{ url_for('all_posts', tag=slug) }}">{{ label }}</a>
     {% endfor %}
   </div>
 {% endif %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -24,8 +24,9 @@
       <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
     </div>
     <div class="mb-3">
-      <label for="post_categories" class="form-label">{{ _('Category tags (comma separated)') }}</label>
-      <input type="text" id="post_categories" name="post_categories" class="form-control" value="{{ post_categories }}">
+      <label for="post_categories" class="form-label">{{ _('Category tags mapping (JSON)') }}</label>
+      <textarea id="post_categories" name="post_categories" class="form-control" rows="3">{{ post_categories }}</textarea>
+      <div class="form-text">{{ _('Example: {"news": {"en": "news", "es": "noticias"}}') }}</div>
     </div>
     <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
   </form>

--- a/tests/test_post_categories.py
+++ b/tests/test_post_categories.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import json
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app import app, db, User, Post, Tag, Setting
+from app import app, db, User, Post, Tag, Setting, get_category_tags
 
 
 @pytest.fixture
@@ -31,16 +32,24 @@ def test_posts_category_filter(client):
         p2 = Post(title='Tech Post', body='b', path='tech', language='en', author=user, tags=[tech])
         p3 = Post(title='Misc Post', body='b', path='misc', language='en', author=user, tags=[misc])
         db.session.add_all([p1, p2, p3])
-        db.session.add(Setting(key='post_categories', value='news, tech'))
+        mapping = {
+            'news': {'en': 'news', 'es': 'noticias'},
+            'tech': {'en': 'tech', 'es': 'tecnologia'},
+        }
+        db.session.add(Setting(key='post_categories', value=json.dumps(mapping)))
         db.session.commit()
 
     resp = client.get('/posts')
     assert resp.status_code == 200
     assert b'?tag=news' in resp.data
     assert b'?tag=tech' in resp.data
+    assert b'>news<' in resp.data
 
     resp = client.get('/posts', query_string={'tag': 'news'})
     assert b'News Post' in resp.data
     assert b'Tech Post' not in resp.data
     assert b'Misc Post' not in resp.data
+
+    with app.app_context():
+        assert ('news', 'noticias') in get_category_tags('es')
 


### PR DESCRIPTION
## Summary
- allow defining category tags via JSON mapping per language
- validate category tag JSON in settings page
- adapt templates and tests for localized categories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e94e06e88329a28de486a8a6928a