### PR TITLE
style: indent TOC according to heading levels

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -127,7 +127,8 @@ textarea::placeholder,
 }
 
 .toc { margin: 0; }
-.toc ul { list-style: none; padding-left: 0; }
+.toc ul { list-style: none; padding-left: 1rem; }
+.toc > ul { padding-left: 0; }
 .toc a { text-decoration: none; }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
## Summary
- indent nested TOC lists to reflect markdown heading hierarchy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea55a0f48329b421db0c3cf36734