### PR TITLE
Hide deleted posts from post listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -915,9 +915,18 @@ def all_posts():
     tag = None
     if tag_name:
         tag = Tag.query.filter_by(name=tag_name).first_or_404()
-        posts = tag.posts
+        posts = (
+            Post.query.join(Post.tags)
+            .filter(Tag.id == tag.id, Post.title != '', Post.body != '')
+            .order_by(Post.id.desc())
+            .all()
+        )
     else:
-        posts = Post.query.order_by(Post.id.desc()).all()
+        posts = (
+            Post.query.filter(Post.title != '', Post.body != '')
+            .order_by(Post.id.desc())
+            .all()
+        )
     categories = get_category_tags()
     return render_template('index.html', posts=posts, tag=tag, categories=categories)
 

--- a/tests/test_posts_exclude_deleted.py
+++ b/tests/test_posts_exclude_deleted.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_deleted_posts_not_listed(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        p1 = Post(title='Visible', body='Content', path='visible', language='en', author=user)
+        p2 = Post(title='Hidden', body='Content', path='hidden', language='en', author=user)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+        p2.title = ''
+        p2.body = ''
+        db.session.commit()
+    resp = client.get('/posts')
+    assert b'Visible' in resp.data
+    assert b'Hidden' not in resp.data


### PR DESCRIPTION
## Summary
- avoid listing posts with empty title and body
- test that deleted posts are not shown in post list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ebc29cf4832985b22d606f7f9fe7