### PR TITLE
Allow custom head meta tags via settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -769,7 +769,7 @@ class Redirect(db.Model):
 
 class Setting(db.Model):
     key = db.Column(db.String(50), primary_key=True)
-    value = db.Column(db.String(200), nullable=True)
+    value = db.Column(db.Text, nullable=True)
 
 def get_setting(key: str, default: str = '') -> str:
     try:
@@ -1885,6 +1885,7 @@ def settings():
     timezone_value = get_setting('timezone', 'UTC')
     rss_enabled_val = get_setting('rss_enabled', 'false')
     rss_limit = get_setting('rss_limit', '20')
+    head_tags = get_setting('head_tags', '')
     if request.method == 'POST':
 
         title = request.form.get('site_title', title).strip()
@@ -1892,6 +1893,7 @@ def settings():
         timezone_value = request.form.get('timezone', timezone_value).strip() or 'UTC'
         rss_enabled_val = 'rss_enabled' in request.form
         rss_limit = request.form.get('rss_limit', rss_limit).strip() or '20'
+        head_tags = request.form.get('head_tags', head_tags).strip()
 
         title_setting = Setting.query.filter_by(key='site_title').first()
         if title_setting:
@@ -1929,6 +1931,12 @@ def settings():
         else:
             db.session.add(Setting(key='rss_limit', value=rss_limit))
 
+        head_setting = Setting.query.filter_by(key='head_tags').first()
+        if head_setting:
+            head_setting.value = head_tags
+        else:
+            db.session.add(Setting(key='head_tags', value=head_tags))
+
         db.session.commit()
         flash(_('Settings updated.'))
         return redirect(url_for('settings'))
@@ -1939,6 +1947,7 @@ def settings():
         timezone=timezone_value,
         rss_enabled=rss_enabled_val.lower() in ['true', '1', 'yes', 'on'],
         rss_limit=rss_limit,
+        head_tags=head_tags,
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  {{ get_setting('head_tags')|safe }}
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,6 +23,10 @@
       <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
       <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
     </div>
+    <div class="mb-3">
+      <label for="head_tags" class="form-label">{{ _('Extra head tags') }}</label>
+      <textarea id="head_tags" name="head_tags" class="form-control" rows="3">{{ head_tags }}</textarea>
+    </div>
     <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
   </form>
 {% endblock %}

--- a/tests/test_head_tags_setting.py
+++ b/tests/test_head_tags_setting.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_custom_head_tags_rendered(client):
+    meta = '<meta name="test" content="value">'
+    with app.app_context():
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        db.session.add(admin)
+        db.session.commit()
+    client.post('/login', data={'username': 'admin', 'password': 'pw'})
+    client.post('/settings', data={'head_tags': meta})
+    resp = client.get('/')
+    assert meta.encode() in resp.data


### PR DESCRIPTION
## Summary
- enable storing additional head tags through settings
- render custom head tags in base template
- add regression test for head tags rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e5d4254c83298040ebe3c47b3448