### PR TITLE
Show views and creation time next to post title

### DIFF
--- a/app.py
+++ b/app.py
@@ -1312,6 +1312,12 @@ def create_post():
 def post_detail(post_id: int):
     post = Post.query.get_or_404(post_id)
     views = increment_view_count(post)
+    first_rev = (
+        Revision.query.filter_by(post_id=post.id)
+        .order_by(Revision.created_at.asc())
+        .first()
+    )
+    created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
     location, warning = extract_location(post_meta)
     location_name = None
@@ -1358,6 +1364,7 @@ def post_detail(post_id: int):
         citations=citations,
         user_citations=user_citations,
         views=views,
+        created_at=created_at,
     )
 
 
@@ -1442,6 +1449,12 @@ def document(language: str, doc_path: str):
             )
         )
     views = increment_view_count(post)
+    first_rev = (
+        Revision.query.filter_by(post_id=post.id)
+        .order_by(Revision.created_at.asc())
+        .first()
+    )
+    created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
     location, warning = extract_location(post_meta)
     location_name = None
@@ -1492,6 +1505,7 @@ def document(language: str, doc_path: str):
         citations=citations,
         user_citations=user_citations,
         views=views,
+        created_at=created_at,
     )
 
 

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 {% block title %}{{ post.title }}{% endblock %}
 {% block content %}
-<h1>{{ post.title }} ({{ post.language }})</h1>
+<div class="d-flex justify-content-between align-items-center">
+  <h1 class="mb-0">{{ post.title }} ({{ post.language }})</h1>
+  <div class="text-muted">
+    {% if created_at %}{{ created_at.strftime('%Y-%m-%d %H:%M') }} · {% endif %}{{ _('Views') }}: {{ views }}
+  </div>
+</div>
 <p><small>{{ post.path }}</small></p>
-<p><small>{{ _('Views') }}: {{ views }}</small></p>
 <div class="row">
   {% if toc %}
   <div class="col-md-3">


### PR DESCRIPTION
## Summary
- Display a post's creation time and view count beside the title
- Compute creation time from earliest revision and pass to template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ecba67e483298fe6207d0a629b05