### PR TITLE
Improve editor layout, tag links and head tag handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1965,7 +1965,8 @@ def settings():
         timezone_value = request.form.get('timezone', timezone_value).strip() or 'UTC'
         rss_enabled_val = 'rss_enabled' in request.form
         rss_limit = request.form.get('rss_limit', rss_limit).strip() or '20'
-        head_tags = request.form.get('head_tags', head_tags).strip()
+        head_tags_input = request.form.get('head_tags', head_tags)
+        head_tags = "\n".join(line.strip() for line in head_tags_input.splitlines() if line.strip())
         category_tags = request.form.get('post_categories', category_tags).strip()
         # Validate category mapping JSON
         try:

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,10 +73,14 @@
     function hideSpinner() { spinnerOverlay.style.display = 'none'; }
     let spinnerCount = 0;
     const originalFetch = window.fetch;
-    window.fetch = function (...args) {
+    // Pass {noSpinner: true} in fetch options to skip the overlay
+    window.fetch = function (resource, config = {}) {
+      if (config && config.noSpinner) {
+        return originalFetch(resource, config);
+      }
       spinnerCount++;
       showSpinner();
-      return originalFetch(...args).finally(() => {
+      return originalFetch(resource, config).finally(() => {
         spinnerCount--;
         if (spinnerCount === 0) hideSpinner();
       });

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -13,9 +13,15 @@
   </div>
   <div class="mb-3">
     <label for="body">{{ _('Body') }}</label>
-    <textarea name="body" id="body" class="form-control" rows="20" cols="50">{{ post.body if post else prefill_body or '' }}</textarea>
+    <div class="row">
+      <div class="col-md-6 mb-3 mb-md-0">
+        <textarea name="body" id="body" class="form-control" rows="20" cols="50">{{ post.body if post else prefill_body or '' }}</textarea>
+      </div>
+      <div class="col-md-6">
+        <div id="preview" class="border p-2"></div>
+      </div>
+    </div>
   </div>
-  <div id="preview"></div>
   {% if post %}
   <div class="mb-3">
     <button type="button" id="suggest-citations" class="btn btn-secondary">{{ _('Suggest Citation') }}</button>
@@ -30,7 +36,7 @@
   <div class="mb-3">
     <label>{{ _('Language code') }}</label>
     {% for lang in languages %}
-    <div class="form-check">
+    <div class="form-check form-check-inline">
       <input class="form-check-input" type="radio" name="language" id="language-{{ lang }}" value="{{ lang }}" {% if lang == selected_language %}checked{% endif %}>
       <label class="form-check-label" for="language-{{ lang }}">{{ lang }}</label>
     </div>
@@ -134,7 +140,8 @@ function updatePreview() {
     body: JSON.stringify({
       text: easyMDE.value(),
       language: document.querySelector('input[name="language"]:checked').value
-    })
+    }),
+    noSpinner: true
   }).then(r => r.json()).then(data => {
     previewEl.innerHTML = data.html || '';
   });

--- a/templates/search.html
+++ b/templates/search.html
@@ -41,12 +41,14 @@
   </div>
 </form>
 {% if all_tags %}
-<p>{{ _('Available tags:') }} {{ all_tags|join(', ') }}</p>
+<p>{{ _('Available tags:') }}
+  {% for tag in all_tags %}<a href="{{ url_for('tag_filter', name=tag) }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+</p>
 {% endif %}
 {% if posts is not none %}
 <ul class="list-group">
   {% for post in posts %}
-    <li class="list-group-item"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}){% if post.tags %} - {{ post.tags|map(attribute='name')|join(', ') }}{% endif %}</li>
+    <li class="list-group-item"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}){% if post.tags %} - {% for tag in post.tags %}<a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}</li>
   {% else %}
     <li class="list-group-item">{{ _('No posts found.') }}</li>
   {% endfor %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -26,6 +26,7 @@
     <div class="mb-3">
       <label for="head_tags" class="form-label">{{ _('Extra head tags') }}</label>
       <textarea id="head_tags" name="head_tags" class="form-control" rows="3">{{ head_tags }}</textarea>
+      <div class="form-text">{{ _('Enter one tag per line') }}</div>
       <label for="post_categories" class="form-label">{{ _('Category tags mapping (JSON)') }}</label>
       <textarea id="post_categories" name="post_categories" class="form-control" rows="3">{{ post_categories }}</textarea>
       <div class="form-text">{{ _('Example: {"news": {"en": "news", "es": "noticias"}}') }}</div>


### PR DESCRIPTION
## Summary
- Arrange editor and preview side by side on desktop and make language radios inline
- Allow fetch calls to skip the global spinner and exclude EasyMDE preview from it
- Link tags in search results and sanitize extra head tags line by line

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0edee7a808329b9eb324db5538a9b