### PR TITLE
feat: move citation suggestions to post view

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -122,6 +122,14 @@
 {% endif %}
 {% if current_user.is_authenticated %}
 <section>
+  <h2>{{ _('Suggest Citation') }}</h2>
+  <button type="button" id="suggest-citations" class="btn btn-secondary">{{ _('Suggest Citation') }}</button>
+  <div id="citation-progress" class="progress d-none mt-2">
+    <div id="citation-progress-bar" class="progress-bar" role="progressbar" style="width:0%"></div>
+  </div>
+  <div id="citation-results" class="mt-3"></div>
+</section>
+<section>
   <h2>{{ _('Add Citation') }}</h2>
   <form id="citation-form" action="{{ url_for('new_citation', post_id=post.id) }}" method="post">
     <div class="mb-3 d-flex gap-2">
@@ -182,6 +190,66 @@
       }
       showSpinner();
   });
+  const suggestBtn = document.getElementById('suggest-citations');
+  if (suggestBtn) {
+      suggestBtn.addEventListener('click', async () => {
+          const lines = {{ post.body | tojson }}.split('\n').filter(l => l.trim());
+          const container = document.getElementById('citation-results');
+          container.innerHTML = '';
+          const progress = document.getElementById('citation-progress');
+          const progressBar = document.getElementById('citation-progress-bar');
+          progress.classList.remove('d-none');
+          progressBar.style.width = '0%';
+          const controller = new AbortController();
+          const { signal } = controller;
+          window.addEventListener('beforeunload', () => controller.abort(), { once: true });
+          for (let i = 0; i < lines.length; i++) {
+              if (signal.aborted) break;
+              const lineSection = document.createElement('div');
+              container.appendChild(lineSection);
+              try {
+                  const resp = await fetch('{{ url_for('citation_suggest_line') }}', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ line: lines[i] }),
+                      signal
+                  });
+                  const data = await resp.json();
+                  if (data.results) {
+                      for (const [sentence, cands] of Object.entries(data.results)) {
+                          const section = document.createElement('div');
+                          const p = document.createElement('p');
+                          p.textContent = sentence;
+                          section.appendChild(p);
+                          cands.forEach(c => {
+                              const pre = document.createElement('pre');
+                              pre.textContent = c.text;
+                              const btn = document.createElement('button');
+                              btn.textContent = '{{ _('Save') }}';
+                              btn.addEventListener('click', () => {
+                                  const fd = new FormData();
+                                  fd.append('citation_text', c.text);
+                                  fetch('{{ url_for('new_citation', post_id=post.id) }}', {
+                                      method: 'POST',
+                                      body: fd
+                                  }).then(() => { btn.disabled = true; });
+                              });
+                              const div = document.createElement('div');
+                              div.appendChild(pre);
+                              div.appendChild(btn);
+                              section.appendChild(div);
+                          });
+                          lineSection.appendChild(section);
+                      }
+                  }
+              } catch (e) {
+                  if (signal.aborted) break;
+              }
+              progressBar.style.width = ((i + 1) / lines.length * 100) + '%';
+          }
+          progress.classList.add('d-none');
+      });
+  }
   </script>
 </section>
 {% endif %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -22,12 +22,7 @@
       </div>
     </div>
   </div>
-  {% if post %}
-  <div class="mb-3">
-    <button type="button" id="suggest-citations" class="btn btn-secondary">{{ _('Suggest Citation') }}</button>
-  </div>
-  <div id="citation-results"></div>
-  {% endif %}
+  
   <div class="mb-3">
     <label for="path">{{ _('Path (e.g., docs/start)') }}</label>
     <input name="path" id="path" class="form-control" placeholder="{{ _('Path (e.g., docs/start)') }}" value="{{ post.path if post else prefill_path or '' }}">
@@ -220,51 +215,5 @@ document.getElementById('find-coordinates').addEventListener('click', function (
     });
 });
 </script>
-{% if post %}
-<script>
-document.getElementById('suggest-citations').addEventListener('click', function () {
-  const body = easyMDE.value();
-  const lines = body.split('\n').filter(l => l.trim());
-  const container = document.getElementById('citation-results');
-  container.innerHTML = '';
-  lines.forEach(line => {
-    const lineSection = document.createElement('div');
-    container.appendChild(lineSection);
-    fetch('{{ url_for('citation_suggest_line') }}', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({line})
-    }).then(r => r.json()).then(data => {
-      if (!data.results) return;
-      for (const [sentence, cands] of Object.entries(data.results)) {
-        const section = document.createElement('div');
-        const p = document.createElement('p');
-        p.textContent = sentence;
-        section.appendChild(p);
-        cands.forEach(c => {
-          const pre = document.createElement('pre');
-          pre.textContent = c.text;
-          const btn = document.createElement('button');
-          btn.textContent = '{{ _('Save') }}';
-          btn.addEventListener('click', () => {
-            const fd = new FormData();
-            fd.append('citation_text', c.text);
-            fetch('{{ url_for('new_citation', post_id=post.id) }}', {
-              method: 'POST',
-              body: fd
-            }).then(() => { btn.disabled = true; });
-          });
-          const div = document.createElement('div');
-          div.appendChild(pre);
-          div.appendChild(btn);
-          section.appendChild(div);
-        });
-        lineSection.appendChild(section);
-      }
-    });
-  });
-});
-</script>
-{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show citation suggestions on post pages instead of edit form
- display progress bar and abort requests on navigation
- remove old suggestion controls from edit form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ef261e5c83298121c489cc666eb9