### PR TITLE
Add post links on tag map

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -60,21 +60,25 @@ const markers = L.markerClusterGroup({
     opacity: 1
   }
 });
-tagLocations.forEach(t => {
-  const marker = L.marker([t.lat, t.lon], {icon: createIcon(t.name)});
-  marker.on('click', () => {
-    const info = tagPosts.find(tp => tp.tag === t.name);
-    if(info){
-      let html = `<h3>${t.name}</h3>`;
-      info.posts.forEach(p => {
-        html += `<div class="mb-2"><a href="${p.url}">${p.title}</a><div class="small text-muted">${p.author} · ${p.views} views</div><p class="small mb-0">${p.snippet}</p></div>`;
-      });
-      infoContent.innerHTML = html;
-      infoDiv.style.display = 'block';
-    }
+  tagLocations.forEach(t => {
+    const marker = L.marker([t.lat, t.lon], {icon: createIcon(t.name)});
+    marker.on('click', () => {
+      const info = tagPosts.find(tp => tp.tag === t.name);
+      if(info){
+        let html = `<h3><a href="${t.url}">${t.name}</a></h3>`;
+        info.posts.forEach(p => {
+          html += `<a href="${p.url}" class="d-block mb-2">`;
+          html += `<div>${p.title}</div>`;
+          html += `<div class="small text-muted">${p.author} · ${p.views} views</div>`;
+          html += `<p class="small mb-0">${p.snippet}</p>`;
+          html += `</a>`;
+        });
+        infoContent.innerHTML = html;
+        infoDiv.style.display = 'block';
+      }
+    });
+    markers.addLayer(marker);
   });
-  markers.addLayer(marker);
-});
 map.addLayer(markers);
 </script>
 {% endblock %}

--- a/tests/test_tags_map.py
+++ b/tests/test_tags_map.py
@@ -36,12 +36,13 @@ def client():
         db.drop_all()
 
 
-def test_tags_page_includes_locations(client):
+def test_tags_page_includes_locations_and_post_links(client):
     resp = client.get('/tags')
     data = resp.get_data(as_text=True)
     assert 'tagLocations' in data
     assert '"lat": 10.0' in data
     assert '/tag/t1' in data
+    assert '/docs/en/p1' in data
 
 
 def test_tags_page_uses_metadata_for_locations(client):


### PR DESCRIPTION
## Summary
- make tag marker popups link to tag page
- show each post under a tag as a clickable link
- test that tag pages include post URLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef964fd08329853d0a4bee100cbf