### PR TITLE
Display metadata table under TOC

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -15,6 +15,26 @@
       <nav class="toc-container sticky-top">
         <h2>{{ _('Contents') }}</h2>
         {{ toc|safe }}
+        {% if metadata %}
+        <h3>{{ _('Common') }}</h3>
+        <table class="table table-sm">
+          <tbody>
+            {% for key, value in metadata.items() %}
+            <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
+        {% if user_metadata %}
+        <h3>{{ _('Your Metadata') }}</h3>
+        <table class="table table-sm">
+          <tbody>
+            {% for key, value in user_metadata.items() %}
+            <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
       </nav>
     </div>
     <div class="d-md-none mb-3">
@@ -28,6 +48,26 @@
         </div>
         <div class="offcanvas-body">
           {{ toc|safe }}
+          {% if metadata %}
+          <h3>{{ _('Common') }}</h3>
+          <table class="table table-sm">
+            <tbody>
+              {% for key, value in metadata.items() %}
+              <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+          {% if user_metadata %}
+          <h3>{{ _('Your Metadata') }}</h3>
+          <table class="table table-sm">
+            <tbody>
+              {% for key, value in user_metadata.items() %}
+              <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
         </div>
       </div>
     </div>
@@ -46,9 +86,34 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
-{% if metadata or user_metadata or location or geodata %}
+{% if not toc and (metadata or user_metadata) %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
+  {% if metadata %}
+  <h3>{{ _('Common') }}</h3>
+  <table class="table table-sm">
+    <tbody>
+      {% for key, value in metadata.items() %}
+      <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+  {% if user_metadata %}
+  <h3>{{ _('Your Metadata') }}</h3>
+  <table class="table table-sm">
+    <tbody>
+      {% for key, value in user_metadata.items() %}
+      <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+{% endif %}
+{% if location or geodata %}
+<section>
+  <h2>{{ _('Location') }}</h2>
   {% if location %}
   <p>
     <strong>{{ _('Location') }}:</strong>
@@ -58,24 +123,8 @@
     <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
   </p>
   {% endif %}
-  {% if metadata %}
-  <h3>{{ _('Common') }}</h3>
-  <ul class="list-group">
-    {% for key, value in metadata.items() %}
-      <li class="list-group-item"><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
-    {% endfor %}
-  </ul>
-  {% endif %}
   {% if geodata %}
   <div id="map"></div>
-  {% endif %}
-  {% if user_metadata %}
-  <h3>{{ _('Your Metadata') }}</h3>
-  <ul class="list-group">
-    {% for key, value in user_metadata.items() %}
-      <li class="list-group-item"><strong>{{ key }}:</strong> {{ value|format_metadata }}</li>
-    {% endfor %}
-  </ul>
   {% endif %}
 </section>
 {% endif %}

--- a/tests/test_metadata_table.py
+++ b/tests/test_metadata_table.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostMetadata
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        post = Post(
+            title='T',
+            body='# H1\ncontent',
+            path='p',
+            language='en',
+            author=user,
+        )
+        db.session.add_all([user, post])
+        db.session.flush()
+        db.session.add(PostMetadata(post=post, key='k', value='v'))
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_metadata_table_under_toc(client):
+    resp = client.get('/docs/en/p')
+    html = resp.get_data(as_text=True)
+    start = html.find('<nav class="toc-container')
+    end = html.find('</nav>', start)
+    nav_html = html[start:end]
+    assert '<table' in nav_html
+    assert 'k' in nav_html
+    assert 'v' in nav_html


### PR DESCRIPTION
## Summary
- Show post metadata and user metadata as tables beneath the Table of Contents
- Move location info to its own section and keep metadata tables when no TOC
- Add regression test for metadata table rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0faa409048329941b9f602e67903b