### PR TITLE
Display location in metadata table

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -18,13 +18,22 @@
       <nav class="toc-container sticky-top">
         <h2>{{ _('Contents') }}</h2>
         {{ toc|safe }}
-        {% if metadata %}
+        {% if metadata or location %}
         <h3>{{ _('Common') }}</h3>
         <table class="table table-sm">
           <tbody>
             {% for key, value in metadata.items() %}
             <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
             {% endfor %}
+            {% if location %}
+            <tr>
+              <th scope="row">{{ _('Location') }}</th>
+              <td>
+                {% if location_name %}{{ location_name }} {% endif %}
+                <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
+              </td>
+            </tr>
+            {% endif %}
           </tbody>
         </table>
         {% endif %}
@@ -51,13 +60,22 @@
         </div>
         <div class="offcanvas-body">
           {{ toc|safe }}
-          {% if metadata %}
+          {% if metadata or location %}
           <h3>{{ _('Common') }}</h3>
           <table class="table table-sm">
             <tbody>
               {% for key, value in metadata.items() %}
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
               {% endfor %}
+              {% if location %}
+              <tr>
+                <th scope="row">{{ _('Location') }}</th>
+                <td>
+                  {% if location_name %}{{ location_name }} {% endif %}
+                  <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
+                </td>
+              </tr>
+              {% endif %}
             </tbody>
           </table>
           {% endif %}
@@ -89,16 +107,25 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
-{% if not toc and (metadata or user_metadata) %}
+{% if not toc and (metadata or user_metadata or location) %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
-  {% if metadata %}
+  {% if metadata or location %}
   <h3>{{ _('Common') }}</h3>
   <table class="table table-sm">
     <tbody>
       {% for key, value in metadata.items() %}
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
       {% endfor %}
+      {% if location %}
+      <tr>
+        <th scope="row">{{ _('Location') }}</th>
+        <td>
+          {% if location_name %}{{ location_name }} {% endif %}
+          <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
+        </td>
+      </tr>
+      {% endif %}
     </tbody>
   </table>
   {% endif %}

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -37,4 +37,9 @@ def test_coordinates_not_list_items(client):
     data = resp.get_data(as_text=True)
     assert '<strong>lat:' not in data
     assert '<strong>lon:' not in data
-    assert '(10.0, 20.0)' in data
+    start = data.find('<h2>Metadata')
+    table_start = data.find('<table', start)
+    table_end = data.find('</table>', table_start)
+    table_html = data[table_start:table_end]
+    assert '<th scope="row">Location</th>' in table_html
+    assert '(10.0, 20.0)' in table_html


### PR DESCRIPTION
## Summary
- Include location details as a table row within post metadata
- Ensure metadata tables render when only location is present
- Test that location appears in metadata table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc5c514c8329af2fc3e4418c9f45