### PR TITLE
Move map and location under TOC metadata

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -186,7 +186,7 @@ pre {
   font-weight: bold;
 }
 
-#map {
+#map, #map-offcanvas {
   height: 400px;
   width: 100%;
   max-width: 600px;
@@ -194,7 +194,7 @@ pre {
 }
 
 @media (max-width: 600px) {
-  #map {
+  #map, #map-offcanvas {
     height: 300px;
   }
 }

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -18,7 +18,7 @@
       <nav class="toc-container sticky-top">
         <h2>{{ _('Contents') }}</h2>
         {{ toc|safe }}
-        {% if metadata or location %}
+        {% if metadata or location or geodata %}
         <h3>{{ _('Common') }}</h3>
         <table class="table table-sm">
           <tbody>
@@ -32,6 +32,12 @@
                 {% if location_name %}{{ location_name }} {% endif %}
                 <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
               </td>
+            </tr>
+            {% endif %}
+            {% if geodata %}
+            <tr>
+              <th scope="row">{{ _('Map') }}</th>
+              <td><div id="map"></div></td>
             </tr>
             {% endif %}
           </tbody>
@@ -60,7 +66,7 @@
         </div>
         <div class="offcanvas-body">
           {{ toc|safe }}
-          {% if metadata or location %}
+          {% if metadata or location or geodata %}
           <h3>{{ _('Common') }}</h3>
           <table class="table table-sm">
             <tbody>
@@ -74,6 +80,12 @@
                   {% if location_name %}{{ location_name }} {% endif %}
                   <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
                 </td>
+              </tr>
+              {% endif %}
+              {% if geodata %}
+              <tr>
+                <th scope="row">{{ _('Map') }}</th>
+                <td><div id="map-offcanvas"></div></td>
               </tr>
               {% endif %}
             </tbody>
@@ -107,10 +119,10 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
-{% if not toc and (metadata or user_metadata or location) %}
+{% if not toc and (metadata or user_metadata or location or geodata) %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
-  {% if metadata or location %}
+  {% if metadata or location or geodata %}
   <h3>{{ _('Common') }}</h3>
   <table class="table table-sm">
     <tbody>
@@ -126,6 +138,12 @@
         </td>
       </tr>
       {% endif %}
+      {% if geodata %}
+      <tr>
+        <th scope="row">{{ _('Map') }}</th>
+        <td><div id="map"></div></td>
+      </tr>
+      {% endif %}
     </tbody>
   </table>
   {% endif %}
@@ -138,23 +156,6 @@
       {% endfor %}
     </tbody>
   </table>
-  {% endif %}
-</section>
-{% endif %}
-{% if location or geodata %}
-<section>
-  <h2>{{ _('Location') }}</h2>
-  {% if location %}
-  <p>
-    <strong>{{ _('Location') }}:</strong>
-    {% if location_name %}
-      {{ location_name }}
-    {% endif %}
-    <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
-  </p>
-  {% endif %}
-  {% if geodata %}
-  <div id="map"></div>
   {% endif %}
 </section>
 {% endif %}
@@ -391,31 +392,33 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script>
   const data = { type: 'FeatureCollection', features: {{ geodata|tojson }} };
-  const map = L.map('map').setView([0, 0], 2);
-  const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
-  const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-  const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
-  const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
-      maxZoom: 19,
-      attribution: '&copy; OpenStreetMap contributors'
-  }).addTo(map);
-  const updateTiles = () => {
-      tiles.setUrl(isDark() ? darkUrl : lightUrl);
-  };
-  const themeToggle = document.getElementById('theme-toggle');
-  if (themeToggle) {
-      themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
-  }
-  const layer = L.geoJSON(data).addTo(map);
-  try {
-    map.fitBounds(layer.getBounds());
-  } catch (e) {
-    // If only a single point, getBounds may return empty; fallback
-    if (data.features.length > 0) {
-      const c = data.features[0].geometry.coordinates;
-      map.setView([c[1], c[0]], 13);
+  document.querySelectorAll('#map, #map-offcanvas').forEach((el) => {
+    const map = L.map(el).setView([0, 0], 2);
+    const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+    const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
+    const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    const updateTiles = () => {
+        tiles.setUrl(isDark() ? darkUrl : lightUrl);
+    };
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
     }
-  }
+    const layer = L.geoJSON(data).addTo(map);
+    try {
+      map.fitBounds(layer.getBounds());
+    } catch (e) {
+      // If only a single point, getBounds may return empty; fallback
+      if (data.features.length > 0) {
+        const c = data.features[0].geometry.coordinates;
+        map.setView([c[1], c[0]], 13);
+      }
+    }
+  });
 </script>
 {% endif %}
 {% endblock %}

--- a/tests/test_metadata_table.py
+++ b/tests/test_metadata_table.py
@@ -23,7 +23,11 @@ def client():
         )
         db.session.add_all([user, post])
         db.session.flush()
-        db.session.add(PostMetadata(post=post, key='k', value='v'))
+        db.session.add_all([
+            PostMetadata(post=post, key='k', value='v'),
+            PostMetadata(post=post, key='lat', value='10'),
+            PostMetadata(post=post, key='lon', value='20'),
+        ])
         db.session.commit()
     with app.test_client() as client:
         yield client
@@ -40,3 +44,14 @@ def test_metadata_table_under_toc(client):
     assert '<table' in nav_html
     assert 'k' in nav_html
     assert 'v' in nav_html
+
+
+def test_map_and_location_moved_under_toc(client):
+    resp = client.get('/docs/en/p')
+    html = resp.get_data(as_text=True)
+    start = html.find('<nav class="toc-container')
+    end = html.find('</nav>', start)
+    nav_html = html[start:end]
+    assert '<div id="map"' in nav_html
+    assert html.count('<div id="map"') == 1
+    assert '<h2>Location</h2>' not in html


### PR DESCRIPTION
## Summary
- Show location info and map within the metadata table beneath the TOC
- Remove separate location section and support map in mobile offcanvas
- Style additional map container and initialize multiple maps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0fed826948329ba0e653432e5eede