### PR TITLE
Tweak map dimensions for better layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -187,15 +187,15 @@ pre {
 }
 
 #map, #map-offcanvas {
-  height: 400px;
+  height: 250px;
   width: 100%;
-  max-width: 600px;
+  max-width: 100%;
   margin: 1em 0;
 }
 
 @media (max-width: 600px) {
   #map, #map-offcanvas {
-    height: 300px;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce map height and remove width cap so embedded maps aren't overly tall and narrow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1008b8f0c8329a208395a246bd38b