### PR TITLE
Enhance notifications with links and improved layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -739,6 +739,7 @@ class Notification(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     message = db.Column(db.String(200), nullable=False)
+    link = db.Column(db.String(200), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     read_at = db.Column(db.DateTime, nullable=True)
 
@@ -1648,10 +1649,11 @@ def new_citation(post_id: int):
         w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
     }
     watcher_ids.add(post.author_id)
+    link = url_for('post_detail', post_id=post.id)
     for uid in watcher_ids:
         if uid != current_user.id:
             msg = _('Citation added to "%(title)s".', title=post.title)
-            db.session.add(Notification(user_id=uid, message=msg))
+            db.session.add(Notification(user_id=uid, message=msg, link=link))
     db.session.commit()
     return redirect(url_for('post_detail', post_id=post.id))
 
@@ -1728,10 +1730,11 @@ def edit_citation(post_id: int, cid: int):
             w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
         }
         watcher_ids.add(post.author_id)
+        link = url_for('post_detail', post_id=post.id)
         for uid in watcher_ids:
             if uid != current_user.id:
                 msg = _('Citation updated on "%(title)s".', title=post.title)
-                db.session.add(Notification(user_id=uid, message=msg))
+                db.session.add(Notification(user_id=uid, message=msg, link=link))
         db.session.commit()
         return redirect(url_for('post_detail', post_id=post.id))
     part_json = json.dumps(citation.citation_part)
@@ -1754,10 +1757,11 @@ def delete_citation(post_id: int, cid: int):
         w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
     }
     watcher_ids.add(post.author_id)
+    link = url_for('post_detail', post_id=post.id)
     for uid in watcher_ids:
         if uid != current_user.id:
             msg = _('Citation deleted from "%(title)s".', title=post.title)
-            db.session.add(Notification(user_id=uid, message=msg))
+            db.session.add(Notification(user_id=uid, message=msg, link=link))
     db.session.commit()
     return redirect(url_for('post_detail', post_id=post.id))
 
@@ -1867,10 +1871,11 @@ def edit_post(post_id: int):
             w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
         }
         watcher_ids.add(post.author_id)
+        link = url_for('post_detail', post_id=post.id)
         for uid in watcher_ids:
             if uid != current_user.id:
                 msg = _('Post "%(title)s" was updated.', title=post.title)
-                db.session.add(Notification(user_id=uid, message=msg))
+                db.session.add(Notification(user_id=uid, message=msg, link=link))
         rev.byte_change = len(post.body) - len(old_body)
         db.session.commit()
         return redirect(url_for('document', language=post.language, doc_path=post.path))
@@ -1951,10 +1956,11 @@ def revert_revision(post_id: int, rev_id: int):
         w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
     }
     watcher_ids.add(post.author_id)
+    link = url_for('post_detail', post_id=post.id)
     for uid in watcher_ids:
         if uid != current_user.id:
             msg = _('Post "%(title)s" was updated.', title=post.title)
-            db.session.add(Notification(user_id=uid, message=msg))
+            db.session.add(Notification(user_id=uid, message=msg, link=link))
 
     db.session.commit()
     flash(_('Post reverted.'))

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -2,10 +2,16 @@
 {% block title %}{{ _('Notifications') }}{% endblock %}
 {% block content %}
 <h1>{{ _('Notifications') }}</h1>
+<p class="text-muted">{{ _('Click a notification to view the related post.') }}</p>
 <ul class="list-group">
   {% for n in notifications %}
-    <li class="list-group-item{% if n.read_at is none %} fw-bold{% endif %}">
-      {{ n.message }} - {{ n.created_at.strftime('%Y-%m-%d %H:%M') }}
+    <li class="list-group-item d-flex justify-content-between align-items-center{% if n.read_at is none %} fw-bold{% endif %}">
+      {% if n.link %}
+        <a href="{{ n.link }}" class="text-decoration-none text-reset">{{ n.message }}</a>
+      {% else %}
+        {{ n.message }}
+      {% endif %}
+      <small class="text-muted">{{ n.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
     </li>
   {% else %}
     <li class="list-group-item">{{ _('No notifications.') }}</li>

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -107,3 +107,22 @@ def test_metadata_update_notifies_author(client):
         assert Notification.query.filter_by(user_id=author.id).count() == 1
         assert Notification.query.filter_by(user_id=admin.id).count() == 0
 
+
+def test_notification_link_rendered(client):
+    post_id = create_post(client)
+    login(client, 'watcher1')
+    client.post(f'/post/{post_id}/watch', data={})
+    logout(client)
+
+    login(client, 'watcher2')
+    client.post(
+        f'/post/{post_id}/citation/new',
+        data={'citation_text': '@article{a,title={t}}'},
+    )
+    logout(client)
+
+    login(client, 'watcher1')
+    resp = client.get('/notifications')
+    assert f'href="/post/{post_id}"' in resp.text
+    logout(client)
+


### PR DESCRIPTION
## Summary
- add optional link to Notification model and populate when posts change
- style notifications with instruction text, timestamp and clickable links
- test that notifications render links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a100d919f883298261a6236229e461