### PR TITLE
docs: add examples for API endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,3 +44,153 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/tag/<string:name>` | `GET` | Filter posts by tag |
 | `/tags` | `GET` | List all tags |
 | `/user/<username>` | `GET, POST` | View or update a user profile |
+
+## JSON API Examples
+
+The following endpoints return JSON responses and can be used programmatically.
+
+### `/markdown/preview` (`POST`)
+
+Render a snippet of Markdown and return the HTML.
+
+**Parameters**
+
+- `text` (string, required) – Markdown source to render
+- `language` (string, optional) – language code used for resolving wiki links
+
+**Example**
+
+Request
+
+```http
+POST /markdown/preview
+Content-Type: application/json
+
+{"text": "[[Page]]", "language": "es"}
+```
+
+Response
+
+```json
+{"html": "<p><a href=\"/docs/es/Page\">Page</a></p>"}
+```
+
+### `/og` (`GET`)
+
+Fetch Open Graph metadata for a URL.
+
+**Parameters**
+
+- `url` (string, required) – absolute URL to inspect
+
+**Example**
+
+Request: `GET /og?url=https://example.com`
+
+Response
+
+```json
+{"title": "Example Domain", "description": "...", "image": null}
+```
+
+### `/geocode` (`GET`)
+
+Return coordinates for a human-readable address.
+
+**Parameters**
+
+- `address` (string, required) – address to geocode
+
+**Example**
+
+Request: `GET /geocode?address=1600+Pennsylvania+Ave+NW`
+
+Response
+
+```json
+{"lat": 38.8977, "lon": -77.0365}
+```
+
+### `/citation/suggest` (`POST`)
+
+Suggest citations for multiple sentences of text.
+
+**Parameters**
+
+- `text` (string, required) – body of text to analyse
+
+**Example**
+
+```http
+POST /citation/suggest
+Content-Type: application/json
+
+{"text": "Albert Einstein was born in Ulm."}
+```
+
+Response
+
+```json
+{
+  "results": {
+    "Albert Einstein was born in Ulm.": [
+      {"text": "@article{...}", "part": {"title": "...", "doi": "10.1000/xyz"}}
+    ]
+  }
+}
+```
+
+### `/citation/suggest_line` (`POST`)
+
+Like `/citation/suggest` but processes one line at a time.
+
+**Parameters**
+
+- `line` (string, required) – single line of text
+
+**Example**
+
+```http
+POST /citation/suggest_line
+Content-Type: application/json
+
+{"line": "Quantum mechanics revolutionised physics."}
+```
+
+Response
+
+```json
+{
+  "results": {
+    "Quantum mechanics revolutionised physics.": [
+      {"text": "@article{...}", "part": {"title": "...", "doi": "10.1000/abc"}}
+    ]
+  }
+}
+```
+
+### `/citation/fetch` (`POST`)
+
+Fetch metadata for the first citation that matches a title.
+
+**Parameters**
+
+- `title` (string, required) – work title used to query Crossref
+
+**Example**
+
+```http
+POST /citation/fetch
+Content-Type: application/json
+
+{"title": "The Meaning of Relativity"}
+```
+
+Response
+
+```json
+{
+  "part": {"title": "The Meaning of Relativity", "doi": "10.1000/rel"},
+  "text": "@book{...}"
+}
+```


### PR DESCRIPTION
## Summary
- expand API endpoint documentation with parameters and sample JSON responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1017258b48329bc080dfc543da4f3