### PR TITLE
Show placeholder for deleted post titles

### DIFF
--- a/templates/admin/posts.html
+++ b/templates/admin/posts.html
@@ -20,7 +20,7 @@
     {% for post in pagination.items %}
     <tr>
       <td>{{ post.id }}</td>
-      <td><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a></td>
+      <td><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a></td>
       <td>{{ post.path }}</td>
       <td>{{ post.language }}</td>
       <td>

--- a/templates/backlinks.html
+++ b/templates/backlinks.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Backlinks for {{ post.title }}{% endblock %}
+{% block title %}Backlinks for {{ post.display_title }}{% endblock %}
 {% block content %}
-<h1>{{ _('Backlinks for "%(title)s"', title=post.title) }}</h1>
+<h1>{{ _('Backlinks for "%(title)s"', title=post.display_title) }}</h1>
 <ul class="list-group">
   {% for p in backlinks %}
-    <li class="list-group-item"><a href="{{ url_for('post_detail', post_id=p.id) }}">{{ p.title }}</a></li>
+    <li class="list-group-item"><a href="{{ url_for('post_detail', post_id=p.id) }}">{{ p.display_title }}</a></li>
   {% else %}
     <li class="list-group-item">{{ _('No backlinks') }}</li>
   {% endfor %}

--- a/templates/citation_form.html
+++ b/templates/citation_form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ _('%(action)s Citation', action=action) }}{% endblock %}
 {% block content %}
-<h1>{{ _('%(action)s Citation for %(title)s', action=action, title=post.title) }}</h1>
+<h1>{{ _('%(action)s Citation for %(title)s', action=action, title=post.display_title) }}</h1>
 <form method="post" onsubmit="return confirm('{{ _('Are you sure?') }}');">
   <div class="mb-3">
     <textarea name="citation_part" placeholder="{{ _('Citation part (JSON)') }}" rows="5" cols="50" class="form-control">{{ citation_part if citation_part else '' }}</textarea>

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -14,7 +14,7 @@
     <td>{{ item.count }}</td>
     <td>
       {% for post in item.posts %}
-        <a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a>{% if not loop.last %}, {% endif %}
+        <a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a>{% if not loop.last %}, {% endif %}
       {% endfor %}
     </td>
   </tr>

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}{{ _('Diff') }} - {{ post.title }}{% endblock %}
+{% block title %}{{ _('Diff') }} - {{ post.display_title }}{% endblock %}
 {% block content %}
-<h1>{{ _('Diff for %(title)s', title=post.title) }}</h1>
+<h1>{{ _('Diff for %(title)s', title=post.display_title) }}</h1>
 <pre>{{ diff }}</pre>
 {% if post_exists %}
 <p><a href="{{ url_for('history', post_id=post.id) }}">{{ _('Back to history') }}</a></p>

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}{{ _('History') }} - {{ post.title }}{% endblock %}
+{% block title %}{{ _('History') }} - {{ post.display_title }}{% endblock %}
 {% block content %}
-<h1>{{ _('History for %(title)s', title=post.title) }}</h1>
+<h1>{{ _('History for %(title)s', title=post.display_title) }}</h1>
 <ul class="list-group">
   {% for rev in revisions %}
       <li class="list-group-item">{{ rev.created_at }} {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a> -

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     <div class="col">
       <div class="card h-100">
         <div class="card-body">
-          <h5 class="card-title"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a></h5>
+          <h5 class="card-title"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a></h5>
           <p class="card-text">{{ post.path }} ({{ post.language }})</p>
           <p class="card-text"><small class="text-muted">{{ _('by') }} <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username }}</a></small></p>
         </div>

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% block title %}{{ post.title }}{% endblock %}
+{% block title %}{{ post.display_title }}{% endblock %}
 {% block content %}
 <nav id="reading-breadcrumb" aria-label="breadcrumb" class="mb-2" style="display:none;">
   <ol class="breadcrumb mb-0"></ol>
 </nav>
 <div class="d-flex justify-content-between align-items-center">
-  <h1 class="mb-0">{{ post.title }} ({{ post.language }})</h1>
+  <h1 class="mb-0">{{ post.display_title }} ({{ post.language }})</h1>
   <div class="text-muted">
     {% if created_at %}{{ created_at.strftime('%Y-%m-%d %H:%M') }} · {% endif %}{{ _('Views') }}: {{ views }}
   </div>
@@ -351,7 +351,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const key = 'postBreadcrumb';
   const maxItems = 10;
-  const title = {{ post.title|tojson }};
+  const title = {{ post.display_title|tojson }};
   const url = window.location.pathname;
   let items;
   try {

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -31,7 +31,7 @@
     <div class="col">
       <div class="card h-100">
         <div class="card-body">
-          <h5 class="card-title"><a href="{{ url_for('document', language=p.language, doc_path=p.path) }}">{{ p.title }}</a></h5>
+          <h5 class="card-title"><a href="{{ url_for('document', language=p.language, doc_path=p.path) }}">{{ p.display_title }}</a></h5>
           <p class="card-text">{{ p.path }} ({{ p.language }})</p>
         </div>
       </div>
@@ -48,7 +48,7 @@
     <div class="col">
       <div class="card h-100">
         <div class="card-body">
-          <h5 class="card-title"><a href="{{ url_for('document', language=p.language, doc_path=p.path) }}">{{ p.title }}</a></h5>
+          <h5 class="card-title"><a href="{{ url_for('document', language=p.language, doc_path=p.path) }}">{{ p.display_title }}</a></h5>
           <p class="card-text">{{ p.path }} ({{ p.language }})</p>
         </div>
       </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -48,7 +48,7 @@
 {% if posts is not none %}
 <ul class="list-group">
   {% for post in posts %}
-    <li class="list-group-item"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.title }}</a> - {{ post.path }} ({{ post.language }}){% if post.tags %} - {% for tag in post.tags %}<a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}</li>
+    <li class="list-group-item"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a> - {{ post.path }} ({{ post.language }}){% if post.tags %} - {% for tag in post.tags %}<a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}</li>
   {% else %}
     <li class="list-group-item">{{ _('No posts found.') }}</li>
   {% endfor %}
@@ -62,7 +62,7 @@
   <p>{{ _('Example posts:') }}</p>
   <ul class="list-group">
     {% for post in examples %}
-      <li class="list-group-item">{{ post.title }} - {{ post.path }} ({{ post.language }})</li>
+      <li class="list-group-item">{{ post.display_title }} - {{ post.path }} ({{ post.language }})</li>
     {% endfor %}
   </ul>
   {% endif %}

--- a/tests/test_delete_post.py
+++ b/tests/test_delete_post.py
@@ -107,3 +107,26 @@ def test_recent_page_links_to_diff_for_deleted_post(client):
     resp = client.get(f'/post/{post_id}/diff/{rev_id}')
     assert resp.status_code == 200
     assert b'-Body' in resp.data
+
+
+def test_deleted_post_shows_placeholder_title(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        post_id = post.id
+    resp = client.post(f'/post/{post_id}/delete')
+    assert resp.status_code == 302
+    resp = client.get(f'/post/{post_id}')
+    assert b'[deleted]' in resp.data


### PR DESCRIPTION
## Summary
- add `display_title` property to Post to show a '[deleted]' placeholder when a page is removed
- use `display_title` across templates so deleted pages have clear titles
- test that deleted posts render the placeholder title

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a103e603d48329929e04b3037167c1