### PR TITLE
feat: search citations by frequent words

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,7 +113,8 @@ Response
 
 ### `/citation/suggest` (`POST`)
 
-Suggest citations for multiple sentences of text.
+Suggest citations for multiple sentences of text. Only the most frequent
+keywords from each sentence are used when querying external services.
 
 **Parameters**
 
@@ -142,7 +143,8 @@ Response
 
 ### `/citation/suggest_line` (`POST`)
 
-Like `/citation/suggest` but processes one line at a time.
+Like `/citation/suggest` but processes one line at a time, extracting the
+most frequent words from that line to build the search query.
 
 **Parameters**
 

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import markdown
+from collections import Counter
 from datetime import datetime, timezone
 from xml.etree.ElementTree import Element, SubElement, tostring
 from urllib.parse import urlparse, quote
@@ -146,19 +147,37 @@ def fetch_bibtex_by_title(title: str) -> str | None:
     return resp.text.strip()
 
 
+STOPWORDS = {
+    'the', 'and', 'or', 'for', 'with', 'to', 'of', 'a', 'an', 'in', 'on',
+    'at', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+    'that', 'this', 'it', 'as', 'we', 'you', 'he', 'she', 'they', 'them',
+    'his', 'her', 'its', 'our', 'their', 'have', 'has', 'had', 'do', 'does',
+    'did'
+}
+
+
 def suggest_citations(markdown_text: str) -> dict[str, list[dict]]:
     """Split markdown text into sentences and return BibTeX suggestions.
 
     Each sentence is queried against Crossref sequentially. For every result
     the BibTeX is fetched and parsed into a dict with ``text`` and ``part``
     (fields without ID/ENTRYTYPE). Sentences with no suggestions are skipped.
+
+    The query to Crossref is built from high‑frequency words within each
+    sentence rather than the full sentence text.
     """
 
     sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", markdown_text) if s.strip()]
     results: dict[str, list[dict]] = {}
     for sentence in sentences:
+        words = re.findall(r"\b\w+\b", sentence.lower())
+        words = [w for w in words if w not in STOPWORDS]
+        if not words:
+            continue
+        freq = Counter(words)
+        query = " ".join([w for w, _ in freq.most_common(5)])
         try:
-            query_res = cr.works(query=sentence, limit=3)
+            query_res = cr.works(query=query, limit=3)
         except Exception:
             continue
         items = query_res.get("message", {}).get("items", [])
@@ -184,8 +203,8 @@ def suggest_citations(markdown_text: str) -> dict[str, list[dict]]:
             entry.pop("ENTRYTYPE", None)
             entry['doi'] = doi
             candidates.append({"text": bibtex, "part": entry, "doi": doi})
-    if candidates:
-        results[sentence] = candidates
+        if candidates:
+            results[sentence] = candidates
     return results
 
 


### PR DESCRIPTION
## Summary
- query citation suggestions using high-frequency keywords instead of full sentences
- document citation suggestion endpoints to mention keyword-based search

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a104b9f41883298c1888bc1ca768c5