### PR TITLE
Display post metadata beneath title

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -4,9 +4,9 @@
 <nav id="reading-breadcrumb" aria-label="breadcrumb" class="mb-2" style="display:none;">
   <ol class="breadcrumb mb-0"></ol>
 </nav>
-<div class="d-flex justify-content-between align-items-center">
+<div class="d-flex flex-column">
   <h1 class="mb-0">{{ post.title }} ({{ post.language }})</h1>
-  <div class="text-muted">
+  <div class="text-muted text-end mt-1">
     {% if created_at %}{{ created_at.strftime('%Y-%m-%d %H:%M') }} · {% endif %}{{ _('Views') }}: {{ views }}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Reposition timestamp and view counter directly under post titles for improved visibility.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a105360ae48329adb7e5ef89d58a7b