### PR TITLE
Allow multiple locations in metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -457,39 +457,40 @@ def format_citation_mla(part: dict, doi: str | None = None) -> Markup:
 app.jinja_env.filters['mla_citation'] = format_citation_mla
 
 
-def extract_location(meta: dict) -> tuple[dict | None, str | None]:
-    """Extract location dict from metadata if within valid range."""
-    location = None
+def extract_locations(meta: dict) -> tuple[list[dict], str | None]:
+    """Extract all location dicts from metadata within valid range."""
+    locations: list[dict] = []
     warning = None
+
+    def add_location(lat, lon):
+        nonlocal warning
+        try:
+            lat_f = float(lat)
+            lon_f = float(lon)
+        except (TypeError, ValueError):
+            return
+        if -90 <= lat_f <= 90 and -180 <= lon_f <= 180:
+            locations.append({'lat': lat_f, 'lon': lon_f})
+        else:
+            warning = COORD_OUT_OF_RANGE_MSG
+
+    # Direct lat/lon fields
+    lat = meta.get('lat') or meta.get('latitude')
+    lon = meta.get('lon') or meta.get('lng') or meta.get('longitude')
+    if lat is not None and lon is not None:
+        add_location(lat, lon)
+
+    # Values that may contain coordinates or GeoJSON
     for value in meta.values():
-        if isinstance(value, dict):
-            lat = value.get('lat') or value.get('latitude')
-            lon = value.get('lon') or value.get('lng') or value.get('longitude')
-            if lat is not None and lon is not None:
-                try:
-                    lat_f = float(lat)
-                    lon_f = float(lon)
-                except (TypeError, ValueError):
-                    continue
-                if -90 <= lat_f <= 90 and -180 <= lon_f <= 180:
-                    location = {'lat': lat_f, 'lon': lon_f}
-                    break
-                warning = COORD_OUT_OF_RANGE_MSG
-    if location is None:
-        lat = meta.get('lat') or meta.get('latitude')
-        lon = meta.get('lon') or meta.get('lng') or meta.get('longitude')
-        if lat is not None and lon is not None:
-            try:
-                lat_f = float(lat)
-                lon_f = float(lon)
-            except (TypeError, ValueError):
-                pass
-            else:
-                if -90 <= lat_f <= 90 and -180 <= lon_f <= 180:
-                    location = {'lat': lat_f, 'lon': lon_f}
-                else:
-                    warning = COORD_OUT_OF_RANGE_MSG
-    return location, warning
+        for feat in parse_geodata(value):
+            geom = feat.get('geometry', {})
+            if geom.get('type') == 'Point':
+                coords = geom.get('coordinates', [])
+                if len(coords) == 2:
+                    lon_f, lat_f = coords
+                    locations.append({'lat': lat_f, 'lon': lon_f})
+
+    return locations, warning
 
 
 def extract_geodata(meta: dict) -> list[dict]:
@@ -1325,14 +1326,15 @@ def post_detail(post_id: int):
     )
     created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
-    location, warning = extract_location(post_meta)
-    location_name = None
-    if location:
-        location_name = reverse_geocode_coords(location['lat'], location['lon'])
+    locations, warning = extract_locations(post_meta)
+    location_list = []
+    for loc in locations:
+        name = reverse_geocode_coords(loc['lat'], loc['lon'])
+        location_list.append({'lat': loc['lat'], 'lon': loc['lon'], 'name': name})
     geodata = extract_geodata(post_meta)
     meta_no_coords = post_meta.copy()
-    if location:
-        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng'):
+    if locations:
+        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
             meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
@@ -1363,8 +1365,7 @@ def post_detail(post_id: int):
         html_body=html_body,
         toc=toc,
         metadata=meta_no_coords,
-        location=location,
-        location_name=location_name,
+        locations=location_list,
         geodata=geodata,
         user_metadata=user_meta,
         citations=citations,
@@ -1462,14 +1463,15 @@ def document(language: str, doc_path: str):
     )
     created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
-    location, warning = extract_location(post_meta)
-    location_name = None
-    if location:
-        location_name = reverse_geocode_coords(location['lat'], location['lon'])
+    locations, warning = extract_locations(post_meta)
+    location_list = []
+    for loc in locations:
+        name = reverse_geocode_coords(loc['lat'], loc['lon'])
+        location_list.append({'lat': loc['lat'], 'lon': loc['lon'], 'name': name})
     geodata = extract_geodata(post_meta)
     meta_no_coords = post_meta.copy()
-    if location:
-        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng'):
+    if locations:
+        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
             meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
@@ -1504,8 +1506,7 @@ def document(language: str, doc_path: str):
         toc=toc,
         translations=translations,
         metadata=meta_no_coords,
-        location=location,
-        location_name=location_name,
+        locations=location_list,
         geodata=geodata,
         user_metadata=user_meta,
         citations=citations,

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -18,21 +18,23 @@
       <nav class="toc-container sticky-top">
         <h2>{{ _('Contents') }}</h2>
         {{ toc|safe }}
-        {% if metadata or location or geodata %}
+        {% if metadata or locations or geodata %}
         <h3>{{ _('Common') }}</h3>
         <table class="table table-sm">
           <tbody>
             {% for key, value in metadata.items() %}
             <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
             {% endfor %}
-            {% if location %}
-            <tr>
-              <th scope="row">{{ _('Location') }}</th>
-              <td>
-                {% if location_name %}{{ location_name }} {% endif %}
-                <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
-              </td>
-            </tr>
+            {% if locations %}
+              {% for loc in locations %}
+              <tr>
+                <th scope="row">{{ _('Location') }}</th>
+                <td>
+                  {% if loc.name %}{{ loc.name }} {% endif %}
+                  <span class="text-muted">({{ loc.lat }}, {{ loc.lon }})</span>
+                </td>
+              </tr>
+              {% endfor %}
             {% endif %}
             {% if geodata %}
             <tr>
@@ -66,21 +68,23 @@
         </div>
         <div class="offcanvas-body">
           {{ toc|safe }}
-          {% if metadata or location or geodata %}
+          {% if metadata or locations or geodata %}
           <h3>{{ _('Common') }}</h3>
           <table class="table table-sm">
             <tbody>
               {% for key, value in metadata.items() %}
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
               {% endfor %}
-              {% if location %}
-              <tr>
-                <th scope="row">{{ _('Location') }}</th>
-                <td>
-                  {% if location_name %}{{ location_name }} {% endif %}
-                  <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
-                </td>
-              </tr>
+              {% if locations %}
+                {% for loc in locations %}
+                <tr>
+                  <th scope="row">{{ _('Location') }}</th>
+                  <td>
+                    {% if loc.name %}{{ loc.name }} {% endif %}
+                    <span class="text-muted">({{ loc.lat }}, {{ loc.lon }})</span>
+                  </td>
+                </tr>
+                {% endfor %}
               {% endif %}
               {% if geodata %}
               <tr>
@@ -119,24 +123,26 @@
     <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
   {% endfor %}
 </p>
-{% if not toc and (metadata or user_metadata or location or geodata) %}
+{% if not toc and (metadata or user_metadata or locations or geodata) %}
 <section>
   <h2>{{ _('Metadata') }}</h2>
-  {% if metadata or location or geodata %}
+  {% if metadata or locations or geodata %}
   <h3>{{ _('Common') }}</h3>
   <table class="table table-sm">
     <tbody>
       {% for key, value in metadata.items() %}
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
       {% endfor %}
-      {% if location %}
-      <tr>
-        <th scope="row">{{ _('Location') }}</th>
-        <td>
-          {% if location_name %}{{ location_name }} {% endif %}
-          <span class="text-muted">({{ location.lat }}, {{ location.lon }})</span>
-        </td>
-      </tr>
+      {% if locations %}
+        {% for loc in locations %}
+        <tr>
+          <th scope="row">{{ _('Location') }}</th>
+          <td>
+            {% if loc.name %}{{ loc.name }} {% endif %}
+            <span class="text-muted">({{ loc.lat }}, {{ loc.lon }})</span>
+          </td>
+        </tr>
+        {% endfor %}
       {% endif %}
       {% if geodata %}
       <tr>

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -101,10 +101,10 @@ formEl.addEventListener('keydown', function (e) {
 });
 
 let metaEditor;
+let initialMeta = {};
 try {
   const metaTextarea = document.getElementById('metadata');
   metaEditor = new JSONEditor(document.getElementById('metadata_editor'), {mode: 'code'});
-  let initialMeta = {};
   if (metaTextarea.value.trim()) {
     try { initialMeta = JSON.parse(metaTextarea.value); } catch (e) {}
   }
@@ -178,21 +178,53 @@ setTimeout(() => map.invalidateSize(), 0);
 
 const latField = document.getElementById('lat');
 const lonField = document.getElementById('lon');
+
+function updateLocations() {
+  const locs = [];
+  let first = null;
+  drawnItems.eachLayer(layer => {
+    const ll = layer.getLatLng();
+    locs.push({lat: ll.lat, lon: ll.lng});
+    if (!first) first = ll;
+  });
+  if (first) {
+    latField.value = first.lat;
+    lonField.value = first.lng;
+  } else {
+    latField.value = '';
+    lonField.value = '';
+  }
+  try {
+    const data = metaEditor.get();
+    data.locations = locs;
+    metaEditor.set(data);
+  } catch (e) {}
+}
+
 const initLat = parseFloat(latField.value);
 const initLon = parseFloat(lonField.value);
-if (!isNaN(initLat) && !isNaN(initLon)) {
+let initialLocations = Array.isArray(initialMeta.locations) ? initialMeta.locations : [];
+if (initialLocations.length) {
+  initialLocations.forEach(loc => {
+    if (loc.lat !== undefined && loc.lon !== undefined) {
+      L.marker([loc.lat, loc.lon]).addTo(drawnItems);
+    }
+  });
+  const first = initialLocations[0];
+  latField.value = first.lat;
+  lonField.value = first.lon;
+  map.setView([first.lat, first.lon], 13);
+} else if (!isNaN(initLat) && !isNaN(initLon)) {
   L.marker([initLat, initLon]).addTo(drawnItems);
   map.setView([initLat, initLon], 13);
 }
 
 map.on(L.Draw.Event.CREATED, function (e) {
-  drawnItems.clearLayers();
-  const layer = e.layer;
-  drawnItems.addLayer(layer);
-  const latlng = layer.getLatLng();
-  latField.value = latlng.lat;
-  lonField.value = latlng.lng;
+  drawnItems.addLayer(e.layer);
+  updateLocations();
 });
+map.on(L.Draw.Event.DELETED, updateLocations);
+map.on(L.Draw.Event.EDITED, updateLocations);
 
 document.getElementById('find-coordinates').addEventListener('click', function () {
   const addr = document.getElementById('address-input').value;
@@ -205,9 +237,9 @@ document.getElementById('find-coordinates').addEventListener('click', function (
         document.getElementById('geocode-error').textContent = '';
         latField.value = data.lat;
         lonField.value = data.lon;
-        drawnItems.clearLayers();
-        L.marker([data.lat, data.lon]).addTo(drawnItems);
+        drawnItems.addLayer(L.marker([data.lat, data.lon]));
         map.setView([data.lat, data.lon], 13);
+        updateLocations();
       }
     })
     .catch(() => {

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -7,7 +7,7 @@ import pytest
 import app
 from app import (
     format_metadata_value,
-    extract_location,
+    extract_locations,
     extract_geodata,
     COORD_OUT_OF_RANGE_MSG,
 )
@@ -39,18 +39,25 @@ def test_format_metadata_value_list_points():
     assert '#map' in result
 
 
-def test_extract_location_valid():
+def test_extract_locations_valid():
     meta = {'location': {'lat': '45', 'lon': '-75'}}
-    loc, warning = extract_location(meta)
-    assert loc == {'lat': 45.0, 'lon': -75.0}
+    locs, warning = extract_locations(meta)
+    assert locs == [{'lat': 45.0, 'lon': -75.0}]
     assert warning is None
 
 
-def test_extract_location_invalid():
+def test_extract_locations_invalid():
     meta = {'lat': '100', 'lon': '50'}
-    loc, warning = extract_location(meta)
-    assert loc is None
+    locs, warning = extract_locations(meta)
+    assert locs == []
     assert warning == COORD_OUT_OF_RANGE_MSG
+
+
+def test_extract_locations_multiple():
+    meta = {'points': [{'lat': '10', 'lon': '20'}, {'lat': 30, 'lon': 40}]}
+    locs, warning = extract_locations(meta)
+    assert warning is None
+    assert locs == [{'lat': 10.0, 'lon': 20.0}, {'lat': 30.0, 'lon': 40.0}]
 
 
 def test_extract_geodata_from_list():

--- a/tests/test_multiple_locations.py
+++ b/tests/test_multiple_locations.py
@@ -1,0 +1,48 @@
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        u = User(username='u', role='editor')
+        u.set_password('pw')
+        db.session.add(u)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'u', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_render_multiple_locations(client):
+    meta = '{"loc1":{"lat":1,"lon":2},"loc2":{"lat":3,"lon":4}}'
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 't',
+            'body': 'b',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': meta,
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        pid = post.id
+    resp = client.get(f'/post/{pid}')
+    html = resp.get_data(as_text=True)
+    assert '(1.0, 2.0)' in html
+    assert '(3.0, 4.0)' in html
+


### PR DESCRIPTION
## Summary
- Support multiple location entries in post metadata
- Render all locations and show them on maps
- Allow adding multiple markers in post form, syncing to metadata
- Add tests for multiple-location handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a105e407508329bfe42b41f00abcd0