### PR TITLE
feat: add multilingual keyword extraction for citations

### DIFF
--- a/API.md
+++ b/API.md
@@ -239,6 +239,8 @@ Response
 
 Suggest citations for multiple sentences of text. Only the most frequent
 keywords from each sentence are used when querying external services.
+Keyword extraction is language-aware and currently supports Korean, English,
+Japanese, French, German and Chinese.
 
 **Parameters**
 

--- a/app.py
+++ b/app.py
@@ -147,13 +147,58 @@ def fetch_bibtex_by_title(title: str) -> str | None:
     return resp.text.strip()
 
 
-STOPWORDS = {
-    'the', 'and', 'or', 'for', 'with', 'to', 'of', 'a', 'an', 'in', 'on',
-    'at', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
-    'that', 'this', 'it', 'as', 'we', 'you', 'he', 'she', 'they', 'them',
-    'his', 'her', 'its', 'our', 'their', 'have', 'has', 'had', 'do', 'does',
-    'did'
+STOPWORDS: dict[str, set[str]] = {
+    'en': {
+        'the', 'and', 'or', 'for', 'with', 'to', 'of', 'a', 'an', 'in', 'on',
+        'at', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+        'that', 'this', 'it', 'as', 'we', 'you', 'he', 'she', 'they', 'them',
+        'his', 'her', 'its', 'our', 'their', 'have', 'has', 'had', 'do', 'does',
+        'did'
+    },
+    'fr': {
+        'le', 'la', 'les', 'un', 'une', 'et', 'ou', 'pour', 'avec', 'à', 'de',
+        'des', 'du', 'est', 'sont', 'il', 'elle', 'nous', 'vous', 'ce', 'ces'
+    },
+    'de': {
+        'der', 'die', 'das', 'und', 'oder', 'für', 'mit', 'zu', 'auf', 'ein',
+        'eine', 'ist', 'sind', 'es', 'ich', 'du', 'er', 'sie', 'wir', 'ihr'
+    },
+    'ko': {
+        '그리고', '또는', '그러나', '그래서', '은', '는', '이', '가', '을', '를',
+        '에', '에서', '에게', '과', '와', '도', '로', '으로', '의'
+    },
+    'ja': {
+        'そして', 'または', 'しかし', 'で', 'は', 'が', 'を', 'に', 'へ', 'と',
+        'も', 'の', 'から', 'まで'
+    },
+    'zh': {
+        '和', '或', '但是', '在', '是', '的', '了', '與', '及', '而且'
+    },
 }
+
+
+def extract_keywords(sentence: str, max_words: int = 5) -> list[str]:
+    """Return up to ``max_words`` keywords from *sentence*.
+
+    Detects the sentence language and removes language-specific stopwords
+    before calculating word frequency.
+    """
+
+    try:
+        lang = detect(sentence)
+    except LangDetectException:
+        lang = 'en'
+    lang = lang.split('-')[0]
+    stopwords = STOPWORDS.get(lang, STOPWORDS['en'])
+    if lang in {'ja', 'zh'}:
+        words = [c for c in sentence if re.match(r"\w", c)]
+    else:
+        words = re.findall(r"\b\w+\b", sentence.lower())
+    words = [w.lower() for w in words if w.lower() not in stopwords]
+    if not words:
+        return []
+    freq = Counter(words)
+    return [w for w, _ in freq.most_common(max_words)]
 
 
 def suggest_citations(markdown_text: str) -> dict[str, list[dict]]:
@@ -170,12 +215,10 @@ def suggest_citations(markdown_text: str) -> dict[str, list[dict]]:
     sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", markdown_text) if s.strip()]
     results: dict[str, list[dict]] = {}
     for sentence in sentences:
-        words = re.findall(r"\b\w+\b", sentence.lower())
-        words = [w for w in words if w not in STOPWORDS]
-        if not words:
+        keywords = extract_keywords(sentence)
+        if not keywords:
             continue
-        freq = Counter(words)
-        query = " ".join([w for w, _ in freq.most_common(5)])
+        query = " ".join(keywords)
         try:
             query_res = cr.works(query=query, limit=3)
         except Exception:

--- a/tests/test_multilingual_keywords.py
+++ b/tests/test_multilingual_keywords.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import extract_keywords
+
+
+def test_extract_keywords_french():
+    sentence = "La science et la technologie avancent rapidement."
+    keywords = extract_keywords(sentence)
+    assert 'la' not in keywords
+    assert 'science' in keywords
+
+
+def test_extract_keywords_chinese():
+    sentence = "这是一个科学的研究。"
+    keywords = extract_keywords(sentence)
+    assert '的' not in keywords
+    assert '是' not in keywords
+    assert len(keywords) > 0


### PR DESCRIPTION
## Summary
- use language detection and multilingual stopword dictionaries to derive keywords
- query citation suggestions using language-aware keywords
- document multilingual support for `/citation/suggest`
- test French and Chinese keyword extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a108c9e11483298b1a8d236ff11ff7