### PR TITLE
Add language-prefixed URLs and user timezone support

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/citation/suggest` | `POST` | Suggest citations for provided text |
 | `/citation/suggest_line` | `POST` | Return citation suggestions for a single line of text |
 | `/citations/stats` | `GET` | Summary statistics for citations |
-| `/docs/<string:language>/<path:doc_path>` | `GET` | Retrieve a document by language and path |
+| `/<string:language>/<path:doc_path>` | `GET` | Retrieve a document by language and path |
 | `/geocode` | `GET` | Geocode an address string |
 | `/login` | `GET, POST` | Log in a user |
 | `/logout` | `GET` | Log out current user |
@@ -110,7 +110,7 @@ Stop watching a post for changes.
 Remove the specified post.
 
 ### `/post/<string:language>/<path:doc_path>` (`GET`)
-Retrieve a post by language and path. The `/docs/<language>/<path>` route is an alias.
+Retrieve a post by language and path. The legacy `/docs/<language>/<path>` route is an alias.
 
 ### `/post/<int:post_id>/edit` (`GET, POST`)
 Edit an existing post. Accepts the same fields as `/post/new` plus an optional `comment`.
@@ -196,7 +196,7 @@ Content-Type: application/json
 Response
 
 ```json
-{"html": "<p><a href=\"/docs/es/Page\">Page</a></p>"}
+{"html": "<p><a href=\"/es/Page\">Page</a></p>"}
 ```
 
 ### `/og` (`GET`)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple wiki-style bulletin board built with Flask and SQLite. Supports user regi
 - User registration and login with role support (admin/user)
 - Create and edit Markdown posts
 - Global tag management; posts can be filtered by tags
-- Hierarchical document paths using `/docs/<lang>/<path>` addresses
+- Hierarchical document paths using `/<lang>/<path>` addresses (legacy `/docs/<lang>/<path>` supported)
 - Link posts written in different languages that share the same path
 - Permissions: authors or admins can edit posts
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -105,6 +105,8 @@
     <a href="{{ url_for('index') }}">{{ _('Home') }}</a>
     |
     <a href="{{ url_for('tag_list') }}">{{ _('Tags') }}</a>
+    |
+    <a href="{{ url_for('choose_timezone') }}">{{ _('Timezone') }}</a>
     {% if get_setting('rss_enabled', 'false').lower() in ['true', '1', 'yes', 'on'] %}
     |
     <a href="{{ url_for('rss_feed') }}">RSS</a>
@@ -142,7 +144,7 @@
       const item = document.createElement('li');
       item.classList.add('list-group-item');
       const link = document.createElement('a');
-      link.href = "/docs/" + data.language + "/" + data.path;
+      link.href = "/" + data.language + "/" + data.path;
       link.textContent = data.title;
       item.appendChild(link);
       list.prepend(item);

--- a/templates/history.html
+++ b/templates/history.html
@@ -4,7 +4,7 @@
 <h1>{{ _('History for %(title)s', title=post.display_title) }}</h1>
 <ul class="list-group">
   {% for rev in revisions %}
-      <li class="list-group-item">{{ rev.created_at }} {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a> -
+      <li class="list-group-item">{{ rev.created_at|format_datetime }} {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a> -
       <a href="{{ url_for('revision_diff', post_id=post.id, rev_id=rev.id) }}">{{ _('diff') }}</a>
       {% if current_user.is_authenticated and current_user.can_edit_posts() %}
         <form action="{{ url_for('revert_revision', post_id=post.id, rev_id=rev.id) }}" method="post" class="d-inline">

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -11,7 +11,7 @@
       {% else %}
         {{ n.message }}
       {% endif %}
-      <small class="text-muted">{{ n.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
+      <small class="text-muted">{{ n.created_at|format_datetime }}</small>
     </li>
   {% else %}
     <li class="list-group-item">{{ _('No notifications.') }}</li>

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -7,7 +7,7 @@
 <div class="d-flex flex-column">
   <h1 class="mb-0">{{ post.title }} ({{ post.language }})</h1>
   <div class="text-muted text-end mt-1">
-    {% if created_at %}{{ created_at.strftime('%Y-%m-%d %H:%M') }} · {% endif %}{{ _('Views') }}: {{ views }}
+    {% if created_at %}{{ created_at|format_datetime }} · {% endif %}{{ _('Views') }}: {{ views }}
   </div>
 </div>
 <p><small>{{ post.path }}</small></p>
@@ -176,7 +176,7 @@
         {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
         {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
-        {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
+        {{ c.created_at|format_datetime }}
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
           <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
           <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
@@ -195,7 +195,7 @@
         {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
         {{ c.citation_part|mla_citation(c.doi) }}
         &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
-        {{ c.created_at.strftime('%Y-%m-%d %H:%M') }}
+        {{ c.created_at|format_datetime }}
         <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
         <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
           <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>

--- a/templates/recent.html
+++ b/templates/recent.html
@@ -5,7 +5,7 @@
 <ul class="list-group">
     {% for rev in revisions %}
       <li class="list-group-item">
-        {{ rev.display_time }} -
+        {{ rev.created_at|format_datetime('%Y-%m-%d %H:%M %Z') }} -
         <a href="{{ url_for('post_detail', post_id=rev.post_id) }}">{{ rev.title }}</a>
         (<a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ _('diff') }}</a>)
         {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a>

--- a/templates/timezone.html
+++ b/templates/timezone.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Timezone') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Timezone') }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="timezone" class="form-label">{{ _('Timezone') }}</label>
+    <input type="text" id="timezone" name="timezone" class="form-control" value="{{ timezone }}">
+  </div>
+  <button type="submit" class="btn btn-primary">{{ _('Save') }}</button>
+</form>
+{% endblock %}

--- a/tests/test_home_page_setting.py
+++ b/tests/test_home_page_setting.py
@@ -31,7 +31,7 @@ def test_home_page_redirect(client):
 
     resp = client.get('/')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/docs/en/home')
+    assert resp.headers['Location'].endswith('/en/home')
 
 
 def test_updating_home_page_path_preserves_site_title(client):

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -10,13 +10,13 @@ from app import app, render_markdown
 def test_render_markdown_and_wikilink():
     html, toc = render_markdown('**bold** and [[Page|link]]')
     assert '<strong>bold</strong>' in html
-    assert '<a href="/docs/Page">link</a>' in html
+    assert '<a href="/Page">link</a>' in html
     assert toc == ''
 
 
 def test_render_markdown_wikilink_spaces():
     html, _ = render_markdown('[[My Page]]')
-    assert '<a href="/docs/My%20Page">My Page</a>' in html
+    assert '<a href="/My%20Page">My Page</a>' in html
 
 
 def test_render_markdown_with_toc_no_headings():
@@ -40,4 +40,4 @@ def client():
 
 def test_markdown_preview_language(client):
     resp = client.post('/markdown/preview', json={'text': '[[Page]]', 'language': 'es'})
-    assert resp.get_json()['html'] == '<p><a href="/docs/es/Page">Page</a></p>'
+    assert resp.get_json()['html'] == '<p><a href="/es/Page">Page</a></p>'

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -53,4 +53,4 @@ def test_redirect_on_path_change(client):
 
     resp = client.get('/docs/en/old')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/docs/en/new')
+    assert resp.headers['Location'].endswith('/en/new')

--- a/tests/test_reverse_geocode.py
+++ b/tests/test_reverse_geocode.py
@@ -61,5 +61,5 @@ def test_doc_path_shows_reverse_geocode(client, monkeypatch):
         },
     )
     assert resp.status_code == 302
-    resp = client.get('/post/en/p')
+    resp = client.get('/en/p')
     assert b'Test Place' in resp.data

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -42,4 +42,4 @@ def test_sitemap(client):
     _create_post()
     resp = client.get('/sitemap.xml')
     assert resp.status_code == 200
-    assert b'http://localhost/docs/en/hello' in resp.data
+    assert b'http://localhost/en/hello' in resp.data

--- a/tests/test_tags_map.py
+++ b/tests/test_tags_map.py
@@ -42,7 +42,7 @@ def test_tags_page_includes_locations_and_post_links(client):
     assert 'tagLocations' in data
     assert '"lat": 10.0' in data
     assert '/tag/t1' in data
-    assert '/docs/en/p1' in data
+    assert '/en/p1' in data
 
 
 def test_tags_page_uses_metadata_for_locations(client):

--- a/tests/test_user_timezone.py
+++ b/tests/test_user_timezone.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from datetime import datetime
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='u', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'u', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_timezone_selection_affects_recent_display(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'T',
+            'body': 'B',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post = Post.query.first()
+        rev = post.revisions[0]
+        rev.created_at = datetime(2024, 1, 1, 0, 0)
+        db.session.commit()
+    client.post('/timezone', data={'timezone': 'Asia/Seoul'})
+    resp = client.get('/recent')
+    assert '09:00' in resp.get_data(as_text=True)
+    assert 'KST' in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- route documents under language-prefixed paths while keeping legacy `/docs` aliases
- let users choose display timezone and render timestamps accordingly
- document new routes and add tests for timezone and path behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a11f749a70832995add47915cb9ee2