### PR TITLE
Allow users to configure locale and timezone

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -3,6 +3,8 @@
 {% block content %}
 <h1>{{ user.username }}</h1>
 <p>{{ user.bio }}</p>
+{% if user.locale %}<p>{{ _('Locale') }}: {{ user.locale }}</p>{% endif %}
+{% if user.timezone %}<p>{{ _('Timezone') }}: {{ user.timezone }}</p>{% endif %}
 <section>
   <h2>{{ _('Contribution Metrics') }}</h2>
   <div class="row row-cols-1 row-cols-sm-2 g-4">
@@ -91,6 +93,18 @@
   <form method="post">
     <div class="mb-3">
       <textarea name="bio" placeholder="{{ _('Bio') }}" rows="4" cols="50" class="form-control">{{ user.bio or '' }}</textarea>
+    </div>
+    <div class="mb-3">
+      <label for="locale" class="form-label">{{ _('Locale') }}</label>
+      <select name="locale" id="locale" class="form-select">
+        {% for lang in languages %}
+        <option value="{{ lang }}" {% if user.locale == lang %}selected{% endif %}>{{ lang }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="timezone" class="form-label">{{ _('Timezone') }}</label>
+      <input type="text" id="timezone" name="timezone" class="form-control" value="{{ user.timezone or '' }}">
     </div>
     <div class="mb-3">
       <button type="submit" class="btn btn-primary">{{ _('Update') }}</button>

--- a/tests/test_user_timezone.py
+++ b/tests/test_user_timezone.py
@@ -1,8 +1,8 @@
 import os
 import sys
 from datetime import datetime
-import pytest
 
+import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import app, db, User, Post
 
@@ -24,7 +24,7 @@ def client():
         db.drop_all()
 
 
-def test_timezone_selection_affects_recent_display(client):
+def test_profile_timezone_and_locale(client):
     resp = client.post(
         '/post/new',
         data={
@@ -43,7 +43,18 @@ def test_timezone_selection_affects_recent_display(client):
         rev = post.revisions[0]
         rev.created_at = datetime(2024, 1, 1, 0, 0)
         db.session.commit()
-    client.post('/timezone', data={'timezone': 'Asia/Seoul'})
+
+    client.post('/user/u', data={'bio': '', 'locale': 'es', 'timezone': 'Asia/Seoul'})
+
+    resp = client.get('/user/u')
+    data = resp.get_data(as_text=True)
+    assert 'Locale' in data
+    assert 'es' in data
+    assert 'Timezone' in data
+    assert 'Asia/Seoul' in data
+
     resp = client.get('/recent')
-    assert '09:00' in resp.get_data(as_text=True)
-    assert 'KST' in resp.get_data(as_text=True)
+    data = resp.get_data(as_text=True)
+    assert '09:00' in data
+    assert 'KST' in data
+


### PR DESCRIPTION
## Summary
- let users configure locale and timezone from their profile
- persist preferences in the User model and apply through Babel selectors
- test profile updates and timezone-aware display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a122c322c883299cc6d1c9d4d44958