### PR TITLE
Handle timezone input case-insensitively

### DIFF
--- a/tests/test_user_timezone.py
+++ b/tests/test_user_timezone.py
@@ -58,3 +58,14 @@ def test_profile_timezone_and_locale(client):
     assert '09:00' in data
     assert 'KST' in data
 
+
+def test_profile_timezone_case_insensitive(client):
+    client.post('/user/u', data={'bio': '', 'locale': 'es', 'timezone': 'asia/seoul'})
+    resp = client.get('/user/u')
+    data = resp.get_data(as_text=True)
+    assert 'Timezone' in data
+    assert 'Asia/Seoul' in data
+    with app.app_context():
+        user = User.query.filter_by(username='u').first()
+        assert user.timezone == 'Asia/Seoul'
+


### PR DESCRIPTION
## Summary
- Add `normalize_timezone` helper to validate and canonicalize timezone names case-insensitively
- Apply normalization when updating user profile, session timezone, and site settings
- Test that lowercase timezone names are accepted

## Testing
- `pytest -q`
- `pytest tests/test_user_timezone.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a124c066c08329acef85da6fb826be