### PR TITLE
Add JSON endpoint for creating posts via Markdown

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,6 +32,7 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/post/<int:post_id>/watch` | `POST` | Watch a post for changes |
 | `/post/<string:language>/<path:doc_path>` | `GET` | View a post by language and path |
 | `/post/new` | `GET, POST` | Create a new post |
+| `/api/posts` | `POST` | Create a new post via JSON |
 | `/post/request` | `GET, POST` | Request that a post be created |
 | `/posts` | `GET` | List all posts |
 | `/posts/requested` | `GET` | List user requested posts |
@@ -93,6 +94,11 @@ List all posts for administrative review.
 Create a new post. POST fields include `title`, `body`, `path`, `language`, `comment`,
 `tags` (comma-separated), optional `metadata` and `user_metadata` JSON strings, and
 optional `lat`/`lon` coordinates.
+
+### `/api/posts` (`POST`)
+Create a new post using a JSON body. Accepts `title` and `body` fields, with optional
+`path`, `language`, and `tags` (comma-separated string or list). Returns basic
+information about the created post.
 
 ### `/post/<int:post_id>` (`GET`)
 View an individual post by ID.
@@ -197,6 +203,34 @@ Response
 
 ```json
 {"html": "<p><a href=\"/es/Page\">Page</a></p>"}
+```
+
+### `/api/posts` (`POST`)
+
+Create a new post with Markdown content.
+
+**Parameters**
+
+- `title` (string, required) – post title
+- `body` (string, required) – Markdown body
+- `path` (string, optional) – desired URL path
+- `language` (string, optional) – language code
+
+**Example**
+
+Request
+
+```http
+POST /api/posts
+Content-Type: application/json
+
+{"title": "API Title", "body": "API Body", "path": "api-path", "language": "en"}
+```
+
+Response
+
+```json
+{"id": 1, "path": "api-path", "language": "en", "title": "API Title"}
 ```
 
 ### `/og` (`GET`)

--- a/app.py
+++ b/app.py
@@ -1464,6 +1464,80 @@ def create_post():
     )
 
 
+@app.route('/api/posts', methods=['POST'])
+@login_required
+def api_create_post():
+    if not current_user.can_edit_posts():
+        return jsonify({'error': 'forbidden'}), 403
+    if not request.is_json:
+        return jsonify({'error': 'invalid JSON'}), 400
+    data = request.get_json() or {}
+    title = (data.get('title') or '').strip()
+    body = (data.get('body') or '').strip()
+    path = (data.get('path') or '').strip()
+    language = (data.get('language') or '').strip()
+    if not title or not body:
+        return jsonify({'error': 'title and body required'}), 400
+    if language not in app.config['LANGUAGES']:
+        try:
+            language = detect(body)
+        except LangDetectException:
+            language = app.config['BABEL_DEFAULT_LOCALE']
+        if language not in app.config['LANGUAGES']:
+            language = app.config['BABEL_DEFAULT_LOCALE']
+    if not path or Post.query.filter_by(path=path, language=language).first():
+        path = generate_unique_path(title, language)
+    tags_input = data.get('tags', [])
+    if isinstance(tags_input, str):
+        tag_names = [t.strip() for t in tags_input.split(',') if t.strip()]
+    else:
+        tag_names = [
+            t.strip() for t in tags_input if isinstance(t, str) and t.strip()
+        ]
+    tags = []
+    for name in tag_names:
+        tag = Tag.query.filter_by(name=name).first()
+        if not tag:
+            tag = Tag(name=name)
+            db.session.add(tag)
+        tags.append(tag)
+    post = Post(
+        title=title,
+        body=body,
+        path=path,
+        language=language,
+        author=current_user,
+        tags=tags,
+    )
+    db.session.add(post)
+    db.session.flush()
+    update_post_links(post)
+    comment = (data.get('comment') or '').strip()
+    rev = Revision(
+        post=post,
+        user=current_user,
+        title=title,
+        body=body,
+        path=path,
+        language=language,
+        comment=comment,
+        byte_change=len(body),
+    )
+    db.session.add(rev)
+    db.session.commit()
+    return (
+        jsonify(
+            {
+                'id': post.id,
+                'path': post.path,
+                'language': post.language,
+                'title': post.title,
+            }
+        ),
+        201,
+    )
+
+
 @app.route('/post/<int:post_id>')
 def post_detail(post_id: int):
     post = Post.query.get_or_404(post_id)

--- a/tests/test_api_create_post.py
+++ b/tests/test_api_create_post.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_api_creates_post_from_markdown(client):
+    resp = client.post(
+        '/api/posts',
+        json={
+            'title': 'API Title',
+            'body': 'API Body',
+            'path': 'api-path',
+            'language': 'en'
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['path'] == 'api-path'
+    with app.app_context():
+        post = Post.query.filter_by(path='api-path', language='en').first()
+        assert post is not None
+        assert post.body == 'API Body'


### PR DESCRIPTION
## Summary
- add `/api/posts` endpoint to create posts via JSON
- document JSON post creation API and include example
- test creating a post through the new endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a12c365368832990945c48a654a14b