### PR TITLE
feat: add location fields to post API

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,7 +32,7 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/post/<int:post_id>/watch` | `POST` | Watch a post for changes |
 | `/post/<string:language>/<path:doc_path>` | `GET` | View a post by language and path |
 | `/post/new` | `GET, POST` | Create a new post |
-| `/api/posts` | `POST` | Create a new post via JSON |
+| `/api/posts` | `POST` | Create a new post via JSON (supports location) |
 | `/post/request` | `GET, POST` | Request that a post be created |
 | `/posts` | `GET` | List all posts |
 | `/posts/requested` | `GET` | List user requested posts |
@@ -97,8 +97,8 @@ optional `lat`/`lon` coordinates.
 
 ### `/api/posts` (`POST`)
 Create a new post using a JSON body. Accepts `title` and `body` fields, with optional
-`path`, `language`, and `tags` (comma-separated string or list). Returns basic
-information about the created post.
+`path`, `language`, `address`, `lat`/`lon`, and `tags` (comma-separated string or list).
+Returns basic information about the created post.
 
 ### `/post/<int:post_id>` (`GET`)
 View an individual post by ID.
@@ -215,6 +215,9 @@ Create a new post with Markdown content.
 - `body` (string, required) – Markdown body
 - `path` (string, optional) – desired URL path
 - `language` (string, optional) – language code
+- `address` (string, optional) – human-readable address to geocode
+- `lat` (number, optional) – latitude; requires `lon`
+- `lon` (number, optional) – longitude; requires `lat`
 
 **Example**
 
@@ -224,7 +227,7 @@ Request
 POST /api/posts
 Content-Type: application/json
 
-{"title": "API Title", "body": "API Body", "path": "api-path", "language": "en"}
+{"title": "API Title", "body": "API Body", "path": "api-path", "language": "en", "lat": 1.0, "lon": 2.0}
 ```
 
 Response

--- a/tests/test_api_create_post.py
+++ b/tests/test_api_create_post.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import pytest
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app import app, db, User, Post
+import app as app_module
+from app import app, db, User, Post, PostMetadata
 
 
 @pytest.fixture
@@ -40,3 +40,49 @@ def test_api_creates_post_from_markdown(client):
         post = Post.query.filter_by(path='api-path', language='en').first()
         assert post is not None
         assert post.body == 'API Body'
+
+
+def test_api_creates_post_with_lat_lon(client):
+    resp = client.post(
+        '/api/posts',
+        json={
+            'title': 'Loc Title',
+            'body': 'Loc Body',
+            'path': 'loc-path',
+            'language': 'en',
+            'lat': 1.0,
+            'lon': 2.0,
+        },
+    )
+    assert resp.status_code == 201
+    with app.app_context():
+        post = Post.query.filter_by(path='loc-path', language='en').first()
+        assert post.latitude == 1.0
+        assert post.longitude == 2.0
+        lat_meta = PostMetadata.query.filter_by(post_id=post.id, key='lat').first()
+        lon_meta = PostMetadata.query.filter_by(post_id=post.id, key='lon').first()
+        assert lat_meta.value == '1.0'
+        assert lon_meta.value == '2.0'
+
+
+def test_api_creates_post_with_address(client, monkeypatch):
+    monkeypatch.setattr(app_module, 'geocode_address', lambda addr: (3.0, 4.0))
+    resp = client.post(
+        '/api/posts',
+        json={
+            'title': 'Addr Title',
+            'body': 'Addr Body',
+            'path': 'addr-path',
+            'language': 'en',
+            'address': 'Somewhere',
+        },
+    )
+    assert resp.status_code == 201
+    with app.app_context():
+        post = Post.query.filter_by(path='addr-path', language='en').first()
+        assert post.latitude == 3.0
+        assert post.longitude == 4.0
+        lat_meta = PostMetadata.query.filter_by(post_id=post.id, key='lat').first()
+        lon_meta = PostMetadata.query.filter_by(post_id=post.id, key='lon').first()
+        assert lat_meta.value == '3.0'
+        assert lon_meta.value == '4.0'


### PR DESCRIPTION
## Summary
- allow `/api/posts` to accept an address or lat/lon coordinates and store them with the post
- document optional `address` and `lat`/`lon` parameters for `/api/posts`
- test post creation via API with coordinates or address

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a12ed0ecdc8329b3bfda1c1ef5d47c