### PR TITLE
Align citation entries to bottom right

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -170,13 +170,10 @@
   <h2>{{ _('Citations') }}</h2>
   {% if citations %}
   <h3>{{ _('Global') }}</h3>
-  <ul class="list-group">
+  <ul class="list-group text-end">
     {% for c in citations %}
-      <li class="list-group-item text-break">
-        {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
-        {{ c.citation_part|mla_citation(c.doi) }}
-        &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
-        {{ c.created_at|format_datetime }}
+      <li class="list-group-item text-break d-flex justify-content-end align-items-center gap-2">
+        <span class="text-end">{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
           <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
           <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
@@ -189,13 +186,10 @@
   {% endif %}
   {% if user_citations %}
   <h3>{{ _('Your Citations') }}</h3>
-  <ul class="list-group">
+  <ul class="list-group text-end">
     {% for c in user_citations %}
-      <li class="list-group-item text-break">
-        {% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}
-        {{ c.citation_part|mla_citation(c.doi) }}
-        &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>,
-        {{ c.created_at|format_datetime }}
+      <li class="list-group-item text-break d-flex justify-content-end align-items-center gap-2">
+        <span class="text-end">{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
         <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
         <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
           <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>


### PR DESCRIPTION
## Summary
- Display global and user citation entries in a single right-aligned row.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a130f3ef308329bef8ba212b1d84b1