### PR TITLE
Add API endpoint for URL-based citations

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,6 +23,7 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/post/<int:post_id>/citation/<int:cid>/delete` | `POST` | Delete a citation from a post |
 | `/post/<int:post_id>/citation/<int:cid>/edit` | `GET, POST` | Edit an existing citation |
 | `/post/<int:post_id>/citation/new` | `POST` | Add a new citation to a post |
+| `/api/posts/<int:post_id>/citation` | `POST` | Add a citation to a post via URL |
 | `/post/<int:post_id>/delete` | `POST` | Delete the specified post |
 | `/post/<int:post_id>/diff/<int:rev_id>` | `GET` | Show differences for a revision |
 | `/post/<int:post_id>/edit` | `GET, POST` | Edit an existing post |
@@ -132,6 +133,9 @@ Revert a post to the specified revision.
 
 ### `/post/<int:post_id>/citation/new` (`POST`)
 Add a citation to a post. Requires `citation_text` and optional `citation_context` fields.
+
+### `/api/posts/<int:post_id>/citation` (`POST`)
+Add a citation to a post by providing a URL in JSON. Requires `url` and optional `context` fields.
 
 ### `/post/<int:post_id>/citation/<int:cid>/edit` (`GET, POST`)
 Edit an existing citation. Accepts the same fields as the new citation endpoint.
@@ -358,4 +362,28 @@ Response
   "part": {"title": "The Meaning of Relativity", "doi": "10.1000/rel"},
   "text": "@book{...}"
 }
+```
+
+### `/api/posts/<int:post_id>/citation` (`POST`)
+
+Add a citation to a post using a URL.
+
+**Parameters**
+
+- `url` (string, required) – citation URL
+- `context` (string, optional) – citation context
+
+**Example**
+
+```http
+POST /api/posts/1/citation
+Content-Type: application/json
+
+{"url": "https://example.com", "context": "Intro"}
+```
+
+Response
+
+```json
+{"id": 1, "url": "https://example.com"}
 ```

--- a/tests/test_api_citation_url.py
+++ b/tests/test_api_citation_url.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_api_add_url_citation(client):
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Title',
+            'body': 'Body',
+            'path': 'p',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post_id = Post.query.first().id
+    resp = client.post(
+        f'/api/posts/{post_id}/citation',
+        json={'url': 'https://example.com', 'context': 'Intro'},
+    )
+    assert resp.status_code == 201
+    assert resp.json['url'] == 'https://example.com'
+    with app.app_context():
+        cit = PostCitation.query.filter_by(post_id=post_id).first()
+        assert cit.citation_text == 'https://example.com'
+        assert cit.context == 'Intro'


### PR DESCRIPTION
## Summary
- Add `/api/posts/<post_id>/citation` endpoint to create citations from URLs
- Document new citation API and usage examples
- Test URL citation JSON endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a135d0b9248329a1f3241d22dd7083