### PR TITLE
Remove global citation heading and left-align citations

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -169,11 +169,10 @@
 <section>
   <h2>{{ _('Citations') }}</h2>
   {% if citations %}
-  <h3>{{ _('Global') }}</h3>
-  <ul class="list-group text-end">
+  <ul class="list-group">
     {% for c in citations %}
-      <li class="list-group-item text-break d-flex justify-content-end align-items-center gap-2">
-        <span class="text-end">{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
+      <li class="list-group-item text-break d-flex align-items-center gap-2">
+        <span>{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
         {% if current_user.is_authenticated and (current_user.id == c.user_id or current_user.is_admin()) %}
           <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
           <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
@@ -186,10 +185,10 @@
   {% endif %}
   {% if user_citations %}
   <h3>{{ _('Your Citations') }}</h3>
-  <ul class="list-group text-end">
+  <ul class="list-group">
     {% for c in user_citations %}
-      <li class="list-group-item text-break d-flex justify-content-end align-items-center gap-2">
-        <span class="text-end">{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
+      <li class="list-group-item text-break d-flex align-items-center gap-2">
+        <span>{% if c.context %}<strong>{{ c.context }}</strong> - {% endif %}{{ c.citation_part|mla_citation(c.doi) }} &mdash; <a href="{{ url_for('profile', username=c.user.username) }}">{{ c.user.username }}</a>, {{ c.created_at|format_datetime }}</span>
         <a href="{{ url_for('edit_citation', post_id=post.id, cid=c.id) }}" class="btn btn-sm btn-secondary">{{ _('Edit') }}</a>
         <form action="{{ url_for('delete_citation', post_id=post.id, cid=c.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Are you sure?') }}');">
           <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -249,10 +249,6 @@ msgstr "Tus metadatos"
 msgid "Citations"
 msgstr "Citas"
 
-#: templates/post_detail.html:37
-msgid "Global"
-msgstr "Global"
-
 #: templates/post_detail.html:48 templates/post_detail.html:66
 msgid "Delete"
 msgstr "Eliminar"


### PR DESCRIPTION
## Summary
- Remove "Global" heading from citation list
- Left-align citation list items instead of right-aligned
- Drop unused translation for "Global"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1368606ac8329873ae83f016e74b9