### PR TITLE
Fix location not updating on post edit

### DIFF
--- a/app.py
+++ b/app.py
@@ -1397,6 +1397,19 @@ def create_post():
         if lat and lon:
             meta_dict['lat'] = lat
             meta_dict['lon'] = lon
+            locs = meta_dict.get('locations')
+            if isinstance(locs, list):
+                if locs:
+                    locs[0]['lat'] = lat
+                    locs[0]['lon'] = lon
+                else:
+                    meta_dict['locations'] = [{'lat': lat, 'lon': lon}]
+            else:
+                meta_dict['locations'] = [{'lat': lat, 'lon': lon}]
+        else:
+            meta_dict.pop('lat', None)
+            meta_dict.pop('lon', None)
+            meta_dict.pop('locations', None)
 
         lat_val = meta_dict.get('lat')
         lon_val = meta_dict.get('lon')
@@ -2139,6 +2152,19 @@ def edit_post(post_id: int):
         if lat and lon:
             meta_dict['lat'] = lat
             meta_dict['lon'] = lon
+            locs = meta_dict.get('locations')
+            if isinstance(locs, list):
+                if locs:
+                    locs[0]['lat'] = lat
+                    locs[0]['lon'] = lon
+                else:
+                    meta_dict['locations'] = [{'lat': lat, 'lon': lon}]
+            else:
+                meta_dict['locations'] = [{'lat': lat, 'lon': lon}]
+        else:
+            meta_dict.pop('lat', None)
+            meta_dict.pop('lon', None)
+            meta_dict.pop('locations', None)
 
         lat_val = meta_dict.get('lat')
         lon_val = meta_dict.get('lon')

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -101,10 +101,10 @@ formEl.addEventListener('keydown', function (e) {
   }
 });
 
+const metaTextarea = document.getElementById('metadata');
 let metaEditor;
 let initialMeta = {};
 try {
-  const metaTextarea = document.getElementById('metadata');
   metaEditor = new JSONEditor(document.getElementById('metadata_editor'), {mode: 'code'});
   if (metaTextarea.value.trim()) {
     try { initialMeta = JSON.parse(metaTextarea.value); } catch (e) {}
@@ -199,6 +199,7 @@ function updateLocations() {
     const data = metaEditor.get();
     data.locations = locs;
     metaEditor.set(data);
+    try { metaTextarea.value = JSON.stringify(metaEditor.get()); } catch (e) {}
   } catch (e) {}
 }
 

--- a/tests/test_edit_location.py
+++ b/tests/test_edit_location.py
@@ -1,0 +1,36 @@
+import os, sys, pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostMetadata
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        u = User(username='u', role='editor')
+        u.set_password('pw')
+        db.session.add(u)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'u', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+def test_edit_updates_location(client):
+    meta = '{"locations":[{"lat":1,"lon":2}]}'
+    client.post('/post/new', data={'title':'t','body':'b','path':'p','language':'en','tags':'','metadata':meta,'user_metadata':'','lat':'1','lon':'2'})
+    with app.app_context():
+        post = Post.query.first()
+        pid = post.id
+    stale_meta = meta
+    client.post(f'/post/{pid}/edit', data={'title':'t','body':'b','path':'p','language':'en','tags':'','metadata':stale_meta,'user_metadata':'','lat':'5','lon':'6'})
+    with app.app_context():
+        loc_meta = PostMetadata.query.filter_by(post_id=pid, key='locations').first()
+        assert loc_meta is not None
+        assert loc_meta.value == [{'lat': '5', 'lon': '6'}]
+        post = Post.query.get(pid)
+        assert post.latitude == 5.0
+        assert post.longitude == 6.0


### PR DESCRIPTION
## Summary
- keep location metadata in sync with lat/lon when creating or editing posts
- sync hidden metadata field with map updates so changes persist
- add regression test for location updates after editing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a138d924348329bca62327bfd98025