### PR TITLE
Add admin statistics dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -2329,6 +2329,20 @@ def admin_posts():
     return render_template('admin/posts.html', pagination=pagination, q=q)
 
 
+@app.route('/admin/stats')
+@login_required
+def admin_stats():
+    if not current_user.is_admin():
+        abort(403)
+    stats = {
+        'users': User.query.count(),
+        'posts': Post.query.count(),
+        'tags': Tag.query.count(),
+        'citations': PostCitation.query.count(),
+    }
+    return render_template('admin/stats.html', stats=stats)
+
+
 @app.route('/settings', methods=['GET', 'POST'])
 @login_required
 def settings():

--- a/templates/admin/stats.html
+++ b/templates/admin/stats.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Statistics') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Statistics') }}</h1>
+<table class="table table-striped">
+  <tr><th>{{ _('Users') }}</th><td>{{ stats.users }}</td></tr>
+  <tr><th>{{ _('Posts') }}</th><td>{{ stats.posts }}</td></tr>
+  <tr><th>{{ _('Tags') }}</th><td>{{ stats.tags }}</td></tr>
+  <tr><th>{{ _('Citations') }}</th><td>{{ stats.citations }}</td></tr>
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}"><i class="bi bi-bar-chart" aria-hidden="true"></i><span class="visually-hidden">{{ _('Citation Stats') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}"><i class="bi bi-mailbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Requested Posts') }}</span></a></li>
         {% if current_user.is_authenticated and current_user.is_admin() %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_stats') }}" aria-label="{{ _('Statistics') }}" title="{{ _('Statistics') }}"><i class="bi bi-graph-up" aria-hidden="true"></i><span class="visually-hidden">{{ _('Statistics') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}"><i class="bi bi-tools" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Posts') }}</span></a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}"><i class="bi bi-inbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Requests') }}</span></a></li>
         {% endif %}

--- a/tests/test_admin_stats.py
+++ b/tests/test_admin_stats.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        user = User(username='user', role='user')
+        user.set_password('pw')
+        db.session.add_all([admin, user])
+        db.session.commit()
+        post = Post(title='T', body='B', path='p', language='en', author=user)
+        db.session.add(post)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'admin', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_admin_stats_counts(client):
+    resp = client.get('/admin/stats')
+    assert resp.status_code == 200
+    assert b'Users</th><td>2' in resp.data
+    assert b'Posts</th><td>1' in resp.data
+
+
+@pytest.fixture
+def normal_client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='user', role='user')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'user', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_non_admin_forbidden(normal_client):
+    resp = normal_client.get('/admin/stats')
+    assert resp.status_code == 403

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -178,6 +178,14 @@ msgstr "Número de usos"
 msgid "Posts"
 msgstr "Publicaciones"
 
+#: templates/admin/stats.html:2 templates/admin/stats.html:4 templates/base.html:27
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: templates/admin/stats.html:6
+msgid "Users"
+msgstr "Usuarios"
+
 #: templates/diff.html:2
 msgid "Diff"
 msgstr "Diferencia"


### PR DESCRIPTION
## Summary
- add `/admin/stats` route showing counts of users, posts, tags and citations
- link statistics page in navbar for authenticated admins
- translate new labels to Spanish and test admin access and stats

## Testing
- `pytest tests/test_admin_stats.py`
- `pytest`
- `pybabel compile -d translations`


------
https://chatgpt.com/codex/tasks/task_e_68a13d17c5e48329b2af185a9ceee743