### PR TITLE
Separate base coordinates from additional locations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1616,15 +1616,40 @@ def post_detail(post_id: int):
     created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
     locations, warning = extract_locations(post_meta)
+    post_lat = post.latitude
+    post_lon = post.longitude
+    if post_lat is not None and post_lon is not None:
+        locations = [
+            loc
+            for loc in locations
+            if not (
+                loc['lat'] == post_lat and loc['lon'] == post_lon
+            )
+        ]
     location_list = []
     for loc in locations:
         name = reverse_geocode_coords(loc['lat'], loc['lon'])
         location_list.append({'lat': loc['lat'], 'lon': loc['lon'], 'name': name})
     geodata = extract_geodata(post_meta)
+    if (
+        post_lat is not None
+        and post_lon is not None
+        and not any(
+            feat.get('geometry', {}).get('type') == 'Point'
+            and feat.get('geometry', {}).get('coordinates') == [post_lon, post_lat]
+            for feat in geodata
+        )
+    ):
+        geodata.append(
+            {
+                'type': 'Feature',
+                'geometry': {'type': 'Point', 'coordinates': [post_lon, post_lat]},
+                'properties': {},
+            }
+        )
     meta_no_coords = post_meta.copy()
-    if locations:
-        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
-            meta_no_coords.pop(key, None)
+    for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
+        meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
     user_meta = {}
@@ -1656,6 +1681,8 @@ def post_detail(post_id: int):
         metadata=meta_no_coords,
         locations=location_list,
         geodata=geodata,
+        lat=post_lat,
+        lon=post_lon,
         user_metadata=user_meta,
         citations=citations,
         user_citations=user_citations,
@@ -1754,15 +1781,40 @@ def document(language: str, doc_path: str):
     created_at = first_rev.created_at if first_rev else None
     post_meta = {m.key: m.value for m in post.metadata}
     locations, warning = extract_locations(post_meta)
+    post_lat = post.latitude
+    post_lon = post.longitude
+    if post_lat is not None and post_lon is not None:
+        locations = [
+            loc
+            for loc in locations
+            if not (
+                loc['lat'] == post_lat and loc['lon'] == post_lon
+            )
+        ]
     location_list = []
     for loc in locations:
         name = reverse_geocode_coords(loc['lat'], loc['lon'])
         location_list.append({'lat': loc['lat'], 'lon': loc['lon'], 'name': name})
     geodata = extract_geodata(post_meta)
+    if (
+        post_lat is not None
+        and post_lon is not None
+        and not any(
+            feat.get('geometry', {}).get('type') == 'Point'
+            and feat.get('geometry', {}).get('coordinates') == [post_lon, post_lat]
+            for feat in geodata
+        )
+    ):
+        geodata.append(
+            {
+                'type': 'Feature',
+                'geometry': {'type': 'Point', 'coordinates': [post_lon, post_lat]},
+                'properties': {},
+            }
+        )
     meta_no_coords = post_meta.copy()
-    if locations:
-        for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
-            meta_no_coords.pop(key, None)
+    for key in ('lat', 'lon', 'latitude', 'longitude', 'lng', 'locations'):
+        meta_no_coords.pop(key, None)
     if warning:
         flash(_(warning))
     user_meta = {}
@@ -1798,6 +1850,8 @@ def document(language: str, doc_path: str):
         metadata=meta_no_coords,
         locations=location_list,
         geodata=geodata,
+        lat=post_lat,
+        lon=post_lon,
         user_metadata=user_meta,
         citations=citations,
         user_citations=user_citations,

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -25,6 +25,10 @@
             {% for key, value in metadata.items() %}
             <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
             {% endfor %}
+            {% if lat is not none and lon is not none %}
+            <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
+            <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
+            {% endif %}
             {% if locations %}
               {% for loc in locations %}
               <tr>
@@ -75,6 +79,10 @@
               {% for key, value in metadata.items() %}
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
               {% endfor %}
+              {% if lat is not none and lon is not none %}
+              <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
+              <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
+              {% endif %}
               {% if locations %}
                 {% for loc in locations %}
                 <tr>
@@ -84,7 +92,7 @@
                     <span class="text-muted">({{ loc.lat }}, {{ loc.lon }})</span>
                   </td>
                 </tr>
-                {% endfor %}
+              {% endfor %}
               {% endif %}
               {% if geodata %}
               <tr>
@@ -133,6 +141,10 @@
       {% for key, value in metadata.items() %}
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
       {% endfor %}
+      {% if lat is not none and lon is not none %}
+      <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
+      <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
+      {% endif %}
       {% if locations %}
         {% for loc in locations %}
         <tr>

--- a/tests/test_metadata_table.py
+++ b/tests/test_metadata_table.py
@@ -11,6 +11,7 @@ def client():
     app.config['TESTING'] = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     with app.app_context():
+        db.drop_all()
         db.create_all()
         user = User(username='u')
         user.set_password('pw')
@@ -23,11 +24,9 @@ def client():
         )
         db.session.add_all([user, post])
         db.session.flush()
-        db.session.add_all([
-            PostMetadata(post=post, key='k', value='v'),
-            PostMetadata(post=post, key='lat', value='10'),
-            PostMetadata(post=post, key='lon', value='20'),
-        ])
+        post.latitude = 10.0
+        post.longitude = 20.0
+        db.session.add(PostMetadata(post=post, key='k', value='v'))
         db.session.commit()
     with app.test_client() as client:
         yield client
@@ -44,6 +43,10 @@ def test_metadata_table_under_toc(client):
     assert '<table' in nav_html
     assert 'k' in nav_html
     assert 'v' in nav_html
+    assert 'Latitude' in nav_html
+    assert '10.0' in nav_html
+    assert 'Longitude' in nav_html
+    assert '20.0' in nav_html
 
 
 def test_map_and_location_moved_under_toc(client):


### PR DESCRIPTION
## Summary
- Show post latitude and longitude separately from other locations
- Include base coordinates in map data and strip them from location metadata
- Test that metadata tables render latitude and longitude rows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a141478bfc832984b26a9819f73bbc