### PR TITLE
Show navbar labels on mobile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,15 +18,15 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('all_posts') }}" aria-label="{{ _('All Posts') }}" title="{{ _('All Posts') }}"><i class="bi bi-card-list" aria-hidden="true"></i><span class="visually-hidden">{{ _('All Posts') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('tag_list') }}" aria-label="{{ _('Tags') }}" title="{{ _('Tags') }}"><i class="bi bi-tags" aria-hidden="true"></i><span class="visually-hidden">{{ _('Tags') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('recent_changes') }}" aria-label="{{ _('Recent changes') }}" title="{{ _('Recent changes') }}"><i class="bi bi-clock-history" aria-hidden="true"></i><span class="visually-hidden">{{ _('Recent changes') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}"><i class="bi bi-bar-chart" aria-hidden="true"></i><span class="visually-hidden">{{ _('Citation Stats') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}"><i class="bi bi-mailbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Requested Posts') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('all_posts') }}" aria-label="{{ _('All Posts') }}" title="{{ _('All Posts') }}"><i class="bi bi-card-list" aria-hidden="true"></i><span class="visually-hidden">{{ _('All Posts') }}</span><span class="d-lg-none ms-1">{{ _('All Posts') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('tag_list') }}" aria-label="{{ _('Tags') }}" title="{{ _('Tags') }}"><i class="bi bi-tags" aria-hidden="true"></i><span class="visually-hidden">{{ _('Tags') }}</span><span class="d-lg-none ms-1">{{ _('Tags') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('recent_changes') }}" aria-label="{{ _('Recent changes') }}" title="{{ _('Recent changes') }}"><i class="bi bi-clock-history" aria-hidden="true"></i><span class="visually-hidden">{{ _('Recent changes') }}</span><span class="d-lg-none ms-1">{{ _('Recent changes') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('citation_stats') }}" aria-label="{{ _('Citation Stats') }}" title="{{ _('Citation Stats') }}"><i class="bi bi-bar-chart" aria-hidden="true"></i><span class="visually-hidden">{{ _('Citation Stats') }}</span><span class="d-lg-none ms-1">{{ _('Citation Stats') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('requested_posts') }}" aria-label="{{ _('Requested Posts') }}" title="{{ _('Requested Posts') }}"><i class="bi bi-mailbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Requested Posts') }}</span><span class="d-lg-none ms-1">{{ _('Requested Posts') }}</span></a></li>
         {% if current_user.is_authenticated and current_user.is_admin() %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_stats') }}" aria-label="{{ _('Statistics') }}" title="{{ _('Statistics') }}"><i class="bi bi-graph-up" aria-hidden="true"></i><span class="visually-hidden">{{ _('Statistics') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}"><i class="bi bi-tools" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Posts') }}</span></a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}"><i class="bi bi-inbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Requests') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_stats') }}" aria-label="{{ _('Statistics') }}" title="{{ _('Statistics') }}"><i class="bi bi-graph-up" aria-hidden="true"></i><span class="visually-hidden">{{ _('Statistics') }}</span><span class="d-lg-none ms-1">{{ _('Statistics') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_posts') }}" aria-label="{{ _('Manage Posts') }}" title="{{ _('Manage Posts') }}"><i class="bi bi-tools" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Posts') }}</span><span class="d-lg-none ms-1">{{ _('Manage Posts') }}</span></a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_requested_posts') }}" aria-label="{{ _('Manage Requests') }}" title="{{ _('Manage Requests') }}"><i class="bi bi-inbox" aria-hidden="true"></i><span class="visually-hidden">{{ _('Manage Requests') }}</span><span class="d-lg-none ms-1">{{ _('Manage Requests') }}</span></a></li>
         {% endif %}
       </ul>
       <form class="d-flex me-3" role="search" action="{{ url_for('search') }}" method="get">
@@ -36,7 +36,7 @@
         {% if current_user.is_authenticated %}
           {% set unread = current_user.notifications | selectattr('read_at', 'equalto', None) | list | length %}
           <li class="nav-item">
-            <a class="nav-link position-relative" href="{{ url_for('notifications') }}" aria-label="{{ _('Notifications') }}" title="{{ _('Notifications') }}" id="notif-link"><i class="bi bi-bell" aria-hidden="true"></i><span class="visually-hidden">{{ _('Notifications') }}</span>
+            <a class="nav-link position-relative" href="{{ url_for('notifications') }}" aria-label="{{ _('Notifications') }}" title="{{ _('Notifications') }}" id="notif-link"><i class="bi bi-bell" aria-hidden="true"></i><span class="visually-hidden">{{ _('Notifications') }}</span><span class="d-lg-none ms-1">{{ _('Notifications') }}</span>
               <span id="notif-count" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" {% if not unread %}style="display:none"{% endif %}>{{ unread }}</span>
             </a>
           </li>
@@ -54,10 +54,10 @@
             </ul>
           </li>
         {% else %}
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}" aria-label="{{ _('Login') }}" title="{{ _('Login') }}"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span class="visually-hidden">{{ _('Login') }}</span></a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}" aria-label="{{ _('Register') }}" title="{{ _('Register') }}"><i class="bi bi-pencil-square" aria-hidden="true"></i><span class="visually-hidden">{{ _('Register') }}</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}" aria-label="{{ _('Login') }}" title="{{ _('Login') }}"><i class="bi bi-box-arrow-in-right" aria-hidden="true"></i><span class="visually-hidden">{{ _('Login') }}</span><span class="d-lg-none ms-1">{{ _('Login') }}</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}" aria-label="{{ _('Register') }}" title="{{ _('Register') }}"><i class="bi bi-pencil-square" aria-hidden="true"></i><span class="visually-hidden">{{ _('Register') }}</span><span class="d-lg-none ms-1">{{ _('Register') }}</span></a></li>
         {% endif %}
-        <li class="nav-item"><button id="theme-toggle" class="btn btn-outline-secondary ms-2" type="button" aria-label="{{ _('Toggle theme') }}"><i class="bi bi-circle-half" aria-hidden="true"></i><span class="visually-hidden">{{ _('Toggle theme') }}</span></button></li>
+        <li class="nav-item"><button id="theme-toggle" class="btn btn-outline-secondary ms-2" type="button" aria-label="{{ _('Toggle theme') }}"><i class="bi bi-circle-half" aria-hidden="true"></i><span class="visually-hidden">{{ _('Toggle theme') }}</span><span class="d-lg-none ms-1">{{ _('Toggle theme') }}</span></button></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Show navigation link labels when viewed on mobile by adding responsive spans to each icon

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1494d074c8329ad1241082835fffb