### PR TITLE
Enable SSL via PEM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ following variables are supported:
 - `BABEL_TRANSLATION_DIRECTORIES` – path to translation files.
 - `HOST` – hostname or IP address for the server.
 - `PORT` – port for the server.
+- `SSL_CERT_FILE` – path to a PEM-formatted certificate file to enable HTTPS.
+- `SSL_KEY_FILE` – path to the private key file if not included in the certificate.
 
 Example `.env`:
 
@@ -41,15 +43,17 @@ LANGUAGES=en,es
 BABEL_TRANSLATION_DIRECTORIES=translations
 HOST=127.0.0.1
 PORT=5000
+SSL_CERT_FILE=cert.pem
+SSL_KEY_FILE=key.pem
 ```
 
 ## Usage
 ```bash
-HOST=127.0.0.1 PORT=5000 python app.py
+HOST=127.0.0.1 PORT=5000 SSL_CERT_FILE=cert.pem SSL_KEY_FILE=key.pem python app.py
 ```
 The application creates `wiki.db` SQLite database on first run.
 
-Open browser at `http://${HOST}:${PORT}/`.
+Open browser at `http://${HOST}:${PORT}/` or `https://${HOST}:${PORT}/` when SSL is configured.
 
 ## API
 

--- a/app.py
+++ b/app.py
@@ -2767,4 +2767,11 @@ if __name__ == '__main__':
         db.create_all()
     host = os.getenv("HOST", "127.0.0.1")
     port = int(os.getenv("PORT", 5000))
-    socketio.run(app, host=host, port=port, debug=True)
+    ssl_cert = os.getenv("SSL_CERT_FILE")
+    ssl_key = os.getenv("SSL_KEY_FILE")
+    ssl_context = None
+    if ssl_cert and ssl_key:
+        ssl_context = (ssl_cert, ssl_key)
+    elif ssl_cert:
+        ssl_context = ssl_cert
+    socketio.run(app, host=host, port=port, debug=True, ssl_context=ssl_context)


### PR DESCRIPTION
## Summary
- allow running the server with SSL by specifying `SSL_CERT_FILE` and `SSL_KEY_FILE`
- document new SSL environment variables and usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14f082f608329a31227dc349ecfe3