### PR TITLE
Fix citation stats layout for long entries

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -184,6 +184,17 @@ pre {
   --bs-table-hover-bg: var(--toc-bg-color);
 }
 
+.citation-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.citation-table th,
+.citation-table td {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 .dark-mode .table,
 .dark-mode .table th,
 .dark-mode .table td,

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -2,7 +2,7 @@
 {% block title %}{{ _('Citation Statistics') }}{% endblock %}
 {% block content %}
 <h1>{{ _('Citation Statistics') }}</h1>
-  <table class="table">
+  <table class="table citation-table">
   <tr>
     <th>{{ _('DOI / Citation') }}</th>
     <th>{{ _('Usage Count') }}</th>


### PR DESCRIPTION
## Summary
- prevent long DOIs or citation strings from breaking citation stats layout
- ensure citation stats table columns stay within page width

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a151d662b48329901023f4b078535e