### PR TITLE
Fix overflow handling in external link modal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -169,6 +169,12 @@ textarea::placeholder,
   border-color: var(--border-color);
 }
 
+#ogTitle,
+#ogDescription {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 pre {
   background-color: var(--nav-bg-color);
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- Prevent long external link titles or descriptions from breaking the modal layout

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a1561aa7708329ab1113e0b1fcb6e1