### PR TITLE
Add pagination to posts page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,19 +14,28 @@
     {% endfor %}
   </div>
 {% endif %}
-<div id="post-list" class="row row-cols-1 row-cols-md-2 g-4">
-  {% for post in posts %}
-    <div class="col">
-      <div class="card h-100">
-        <div class="card-body">
-          <h5 class="card-title"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a></h5>
-          <p class="card-text">{{ post.path }} ({{ post.language }})</p>
-          <p class="card-text"><small class="text-muted">{{ _('by') }} <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username }}</a></small></p>
-        </div>
-      </div>
-    </div>
+<ul id="post-list" class="list-group mb-3">
+  {% for post in pagination.items %}
+    <li class="list-group-item">
+      <h5 class="mb-1"><a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a></h5>
+      <p class="mb-1">{{ post.path }} ({{ post.language }})</p>
+      <small class="text-muted">{{ _('by') }} <a href="{{ url_for('profile', username=post.author.username) }}">{{ post.author.username }}</a></small>
+    </li>
   {% else %}
-    <p>{{ _('No posts yet.') }}</p>
+    <li class="list-group-item">{{ _('No posts yet.') }}</li>
   {% endfor %}
-</div>
+</ul>
+<nav>
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('all_posts', page=pagination.prev_num, tag=tag.name if tag else None) }}">&laquo;</a>
+    </li>
+    {% for p in range(1, pagination.pages + 1) %}
+    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('all_posts', page=p, tag=tag.name if tag else None) }}">{{ p }}</a></li>
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('all_posts', page=pagination.next_num, tag=tag.name if tag else None) }}">&raquo;</a>
+    </li>
+  </ul>
+</nav>
 {% endblock %}

--- a/tests/test_all_posts_route.py
+++ b/tests/test_all_posts_route.py
@@ -34,3 +34,30 @@ def test_all_posts_route_returns_list(client):
     assert b'Home' in resp.data
     assert b'Other' in resp.data
     assert b'href="/posts"' in resp.data
+
+
+def test_posts_pagination(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        for i in range(25):
+            db.session.add(
+                Post(
+                    title=f'Post {i}',
+                    body='Content',
+                    path=f'post-{i}',
+                    language='en',
+                    author=user,
+                )
+            )
+        db.session.commit()
+
+    resp = client.get('/posts')
+    assert resp.status_code == 200
+    assert b'Post 24' in resp.data
+    assert b'Post 4' not in resp.data
+
+    resp = client.get('/posts', query_string={'page': 2})
+    assert b'Post 4' in resp.data
+    assert b'Post 24' not in resp.data


### PR DESCRIPTION
## Summary
- paginate `/posts` results and tag-filtered pages
- render posts page as list with pagination navigation
- test pagination behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a15d63b6bc832986fc8d6d71b2a5c2