### PR TITLE
Allow configuring reading history size and limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -2467,6 +2467,7 @@ def settings():
     rss_limit = get_setting('rss_limit', '20')
     head_tags = get_setting('head_tags', '')
     category_tags = get_setting('post_categories', '')
+    breadcrumb_limit = get_setting('breadcrumb_limit', '10')
     if request.method == 'POST':
 
         title = request.form.get('site_title', title).strip()
@@ -2479,6 +2480,7 @@ def settings():
         timezone_value = tz_norm
         rss_enabled_val = 'rss_enabled' in request.form
         rss_limit = request.form.get('rss_limit', rss_limit).strip() or '20'
+        breadcrumb_limit = request.form.get('breadcrumb_limit', breadcrumb_limit).strip() or '10'
         head_tags_input = request.form.get('head_tags', head_tags)
         head_tags = "\n".join(line.strip() for line in head_tags_input.splitlines() if line.strip())
         category_tags = request.form.get('post_categories', category_tags).strip()
@@ -2534,6 +2536,11 @@ def settings():
             cat_setting.value = category_tags
         else:
             db.session.add(Setting(key='post_categories', value=category_tags))
+        breadcrumb_setting = Setting.query.filter_by(key='breadcrumb_limit').first()
+        if breadcrumb_setting:
+            breadcrumb_setting.value = breadcrumb_limit
+        else:
+            db.session.add(Setting(key='breadcrumb_limit', value=breadcrumb_limit))
 
         db.session.commit()
         flash(_('Settings updated.'))
@@ -2546,7 +2553,8 @@ def settings():
         rss_enabled=rss_enabled_val.lower() in ['true', '1', 'yes', 'on'],
         rss_limit=rss_limit,
         head_tags=head_tags,
-        post_categories=category_tags
+        post_categories=category_tags,
+        breadcrumb_limit=breadcrumb_limit
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -218,6 +218,10 @@ pre {
   font-weight: bold;
 }
 
+#reading-breadcrumb {
+  font-size: 0.9rem;
+}
+
 #map, #map-offcanvas {
   height: 250px;
   width: 100%;

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -363,7 +363,7 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const key = 'postBreadcrumb';
-  const maxItems = 10;
+  const maxItems = {{ get_setting('breadcrumb_limit', '10')|int }};
   const title = {{ post.display_title|tojson }};
   const deleteLabel = {{ _('Delete')|tojson }};
   const url = window.location.pathname;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -19,14 +19,18 @@
       <input class="form-check-input" type="checkbox" id="rss_enabled" name="rss_enabled" {% if rss_enabled %}checked{% endif %}>
       <label class="form-check-label" for="rss_enabled">{{ _('Enable RSS feed') }}</label>
     </div>
-    <div class="mb-3">
-      <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
-      <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
-    </div>
-    <div class="mb-3">
-      <label for="head_tags" class="form-label">{{ _('Extra head tags') }}</label>
-      <textarea id="head_tags" name="head_tags" class="form-control" rows="3">{{ head_tags }}</textarea>
-      <div class="form-text">{{ _('Enter one tag per line') }}</div>
+      <div class="mb-3">
+        <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
+        <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
+      </div>
+      <div class="mb-3">
+        <label for="breadcrumb_limit" class="form-label">{{ _('Reading history limit') }}</label>
+        <input type="number" id="breadcrumb_limit" name="breadcrumb_limit" class="form-control" value="{{ breadcrumb_limit }}">
+      </div>
+      <div class="mb-3">
+        <label for="head_tags" class="form-label">{{ _('Extra head tags') }}</label>
+        <textarea id="head_tags" name="head_tags" class="form-control" rows="3">{{ head_tags }}</textarea>
+        <div class="form-text">{{ _('Enter one tag per line') }}</div>
       <label for="post_categories" class="form-label">{{ _('Category tags mapping (JSON)') }}</label>
       <textarea id="post_categories" name="post_categories" class="form-control" rows="3">{{ post_categories }}</textarea>
       <div class="form-text">{{ _('Example: {"news": {"en": "news", "es": "noticias"}}') }}</div>

--- a/tests/test_breadcrumb_limit_setting.py
+++ b/tests/test_breadcrumb_limit_setting.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Setting
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['LANGUAGES'] = ['en', 'ko']
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_breadcrumb_limit_setting(client):
+    with app.app_context():
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        db.session.add(admin)
+        post = Post(title='Hello', body='Body', path='hello', language='en', author=admin)
+        db.session.add(post)
+        db.session.commit()
+        pid = post.id
+    client.post('/login', data={'username': 'admin', 'password': 'pw'})
+    client.post('/settings', data={'breadcrumb_limit': '5'})
+    resp = client.get(f'/post/{pid}')
+    assert b'const maxItems = 5;' in resp.data
+    with app.app_context():
+        assert Setting.query.filter_by(key='breadcrumb_limit').first().value == '5'


### PR DESCRIPTION
## Summary
- Reduce reading history breadcrumb font size
- Make breadcrumb item limit configurable through settings
- Test breadcrumb limit setting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a15dfdac248329bb3ee2489d519f1c