### PR TITLE
Add pagination to citation statistics

### DIFF
--- a/API.md
+++ b/API.md
@@ -179,6 +179,12 @@ Fetch citation metadata for the provided `title`.
 ### `/citations/stats` (`GET`)
 Return summary statistics for citations across posts.
 
+**Query Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `page` | integer | Page number of results to return (default `1`). Results are paginated with 20 items per page. |
+
 ## JSON API Examples
 
 The following endpoints return JSON responses and can be used programmatically.

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -20,4 +20,19 @@
   </tr>
   {% endfor %}
 </table>
+<nav>
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('citation_stats', page=pagination.prev_num) }}">&laquo;</a>
+    </li>
+    {% for p in range(1, pagination.pages + 1) %}
+    <li class="page-item{% if p == pagination.page %} active{% endif %}">
+      <a class="page-link" href="{{ url_for('citation_stats', page=p) }}">{{ p }}</a>
+    </li>
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('citation_stats', page=pagination.next_num) }}">&raquo;</a>
+    </li>
+  </ul>
+</nav>
 {% endblock %}

--- a/tests/test_citation_stats_pagination.py
+++ b/tests/test_citation_stats_pagination.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        post = Post(title='Post', body='Content', path='post', language='en', author=user)
+        db.session.add(post)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_citation_stats_pagination(client):
+    with app.app_context():
+        user = User.query.first()
+        post = Post.query.first()
+        for i in range(25):
+            db.session.add(
+                PostCitation(
+                    post_id=post.id,
+                    user_id=user.id,
+                    citation_part={'title': f'title{i}'},
+                    citation_text=f'Cite {i}',
+                    context='',
+                    doi=f'10.1000/{i}',
+                    bibtex_raw='@article{a}',
+                    bibtex_fields={'title': f'title{i}'},
+                )
+            )
+        db.session.commit()
+
+    resp = client.get('/citations/stats')
+    assert resp.status_code == 200
+    assert resp.data.count(b'<tr>') - 1 == 20
+
+    resp = client.get('/citations/stats', query_string={'page': 2})
+    assert resp.status_code == 200
+    assert resp.data.count(b'<tr>') - 1 == 5


### PR DESCRIPTION
## Summary
- paginate `/citations/stats` with `page` query parameter
- add pagination controls to citation statistics template
- document new pagination parameter
- test citation stats pagination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a162ae342c83298a21407067dd9dca