### PR TITLE
Adjust citation stats column widths

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -195,6 +195,21 @@ pre {
   width: 100%;
 }
 
+.citation-table th:first-child,
+.citation-table td:first-child {
+  width: 45%;
+}
+
+.citation-table th:nth-child(2),
+.citation-table td:nth-child(2) {
+  width: 10%;
+}
+
+.citation-table th:nth-child(3),
+.citation-table td:nth-child(3) {
+  width: 45%;
+}
+
 .citation-table th,
 .citation-table td {
   word-break: break-word;


### PR DESCRIPTION
## Summary
- widen DOI/Citation and Posts columns in citation statistics table to provide more space for long text

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a162e94324832980907d4ec0cc7ada