### PR TITLE
Hide deleted tags and space tag markers

### DIFF
--- a/app.py
+++ b/app.py
@@ -2562,7 +2562,11 @@ def settings():
 
 @app.route('/tags')
 def tag_list():
-    tags = Tag.query.order_by(Tag.name).all()
+    tags = (
+        Tag.query.filter(~Tag.name.in_(['deleted', '[deleted]']))
+        .order_by(Tag.name)
+        .all()
+    )
     tag_locations = []
     tag_info = []
     tag_posts_data = []

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -47,11 +47,11 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 function createIcon(name){
   const svg = `\
-  <svg xmlns="http://www.w3.org/2000/svg" width="120" height="40">
-    <rect width="120" height="40" rx="5" ry="5" fill="#0d6efd" fill-opacity="0.1" stroke-width="0" />
-    <text x="60" y="25" font-size="14" text-anchor="middle" fill="#0d6efd">${name}</text>
+  <svg xmlns="http://www.w3.org/2000/svg" width="140" height="50">
+    <rect x="10" y="5" width="120" height="40" rx="5" ry="5" fill="#0d6efd" fill-opacity="0.1" stroke-width="0" />
+    <text x="70" y="30" font-size="14" text-anchor="middle" fill="#0d6efd">${name}</text>
   </svg>`;
-  return L.divIcon({html: svg, className: '', iconSize:[120,40], iconAnchor:[60,40]});
+  return L.divIcon({html: svg, className: '', iconSize:[140,50], iconAnchor:[70,50]});
 }
 const markers = L.markerClusterGroup({
   spiderLegPolylineOptions: {

--- a/tests/test_tags_map.py
+++ b/tests/test_tags_map.py
@@ -70,3 +70,24 @@ def test_tags_page_uses_metadata_for_locations(client):
     data = resp.get_data(as_text=True)
     assert '"lat": 30.0' in data
     assert '/tag/t2' in data
+
+
+def test_deleted_tag_is_excluded(client):
+    with app.app_context():
+        user = User.query.filter_by(username='u').first()
+        tag = Tag(name='[deleted]')
+        db.session.add(tag)
+        db.session.commit()
+        post = Post(
+            title='Deleted',
+            body='b',
+            path='pd',
+            language='en',
+            author_id=user.id,
+            tags=[tag],
+        )
+        db.session.add(post)
+        db.session.commit()
+    resp = client.get('/tags')
+    data = resp.get_data(as_text=True)
+    assert '[deleted]' not in data


### PR DESCRIPTION
## Summary
- Skip tags named "deleted" or "[deleted]" on the `/tags` page
- Add padding around tag SVG markers for clearer spacing on the map
- Test that deleted tags are excluded from the tags page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1636894b483299930de6b253926bf