### PR TITLE
Add pagination to search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import markdown
+import math
 from collections import Counter
 from datetime import datetime, timezone
 from xml.etree.ElementTree import Element, SubElement, tostring
@@ -19,6 +20,7 @@ from flask import (
     jsonify,
     Response,
     session,
+    current_app,
 )
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import (LoginManager, login_user, login_required,
@@ -2646,6 +2648,8 @@ def search():
     lat = request.args.get('lat', type=float)
     lon = request.args.get('lon', type=float)
     radius = request.args.get('radius', type=float)
+    page = request.args.get('page', 1, type=int)
+    per_page = current_app.config.get('SEARCH_RESULTS_PER_PAGE', 20)
 
     # Gather distinct metadata keys for the dropdown and include title/path
     meta_keys = [k for (k,) in db.session.query(PostMetadata.key).distinct().all()]
@@ -2681,21 +2685,41 @@ def search():
     else:
         # Provide example posts to illustrate expected input format
         examples = Post.query.limit(5).all()
-
-    posts = posts_query
-    if posts is not None:
+    posts = None
+    pagination = None
+    if posts_query is not None:
         for name in tag_names:
-            posts = posts.filter(Post.tags.any(Tag.name == name))
-        posts = posts.all()
+            posts_query = posts_query.filter(Post.tags.any(Tag.name == name))
 
-    if posts is not None and lat is not None and lon is not None and radius is not None:
-        posts = [
-            p
-            for p in posts
-            if p.latitude is not None
-            and p.longitude is not None
-            and geopy_distance((lat, lon), (p.latitude, p.longitude)).km <= radius
-        ]
+        if lat is not None and lon is not None and radius is not None:
+            all_posts = posts_query.all()
+            filtered_posts = [
+                p
+                for p in all_posts
+                if p.latitude is not None
+                and p.longitude is not None
+                and geopy_distance((lat, lon), (p.latitude, p.longitude)).km <= radius
+            ]
+            total = len(filtered_posts)
+            start = (page - 1) * per_page
+            end = start + per_page
+            items = filtered_posts[start:end]
+            pagination = SimpleNamespace(
+                items=items,
+                page=page,
+                per_page=per_page,
+                total=total,
+                pages=math.ceil(total / per_page) if per_page else 0,
+                has_prev=page > 1,
+                has_next=page < math.ceil(total / per_page),
+                prev_num=page - 1,
+                next_num=page + 1,
+            )
+            posts = items
+        else:
+            posts_query = posts_query.order_by(Post.id.desc())
+            pagination = posts_query.paginate(page=page, per_page=per_page, error_out=False)
+            posts = pagination.items
 
     coords_json = (
         json.dumps([{'lat': p.latitude, 'lon': p.longitude} for p in posts])
@@ -2706,6 +2730,7 @@ def search():
     return render_template(
         'search.html',
         posts=posts,
+        pagination=pagination,
         q=q,
         tags=tags_raw,
         all_tags=all_tags,

--- a/templates/search.html
+++ b/templates/search.html
@@ -53,6 +53,21 @@
     <li class="list-group-item">{{ _('No posts found.') }}</li>
   {% endfor %}
 </ul>
+{% if pagination and pagination.pages > 1 %}
+<nav>
+  <ul class="pagination">
+    <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('search', page=pagination.prev_num, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">&laquo;</a>
+    </li>
+    {% for p in range(1, pagination.pages + 1) %}
+    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('search', page=p, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">{{ p }}</a></li>
+    {% endfor %}
+    <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('search', page=pagination.next_num, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">&raquo;</a>
+    </li>
+  </ul>
+</nav>
+{% endif %}
   <script>
     const postCoords = {{ coords_json|safe }};
   </script>


### PR DESCRIPTION
## Summary
- add server-side pagination to search endpoint
- render pagination controls on search template
- test search pagination and FTS behavior

## Testing
- `pytest`
- `pytest tests/test_search_fts.py tests/test_search_location.py tests/test_search_pagination.py`

------
https://chatgpt.com/codex/tasks/task_e_68a16328bbbc83299af540608ed873cf