### PR TITLE
Add fullscreen toggle for metadata map

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -244,6 +244,20 @@ pre {
   margin: 1em 0;
 }
 
+.map-fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  z-index: 2000;
+}
+
+.map-fullscreen .leaflet-control-container {
+  z-index: 2001;
+}
+
 @media (max-width: 600px) {
   #map, #map-offcanvas {
     height: 200px;

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -443,6 +443,25 @@ document.addEventListener('DOMContentLoaded', () => {
     if (themeToggle) {
         themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
     }
+    const toggleFullscreen = () => {
+      el.classList.toggle('map-fullscreen');
+      document.body.classList.toggle('overflow-hidden');
+      setTimeout(() => map.invalidateSize(), 200);
+    };
+    const fullscreenControl = L.control({position: 'topleft'});
+    fullscreenControl.onAdd = () => {
+      const btn = L.DomUtil.create('button', 'btn btn-sm btn-light');
+      btn.type = 'button';
+      btn.innerHTML = '⛶';
+      btn.title = 'Toggle fullscreen';
+      L.DomEvent.on(btn, 'click', (e) => {
+        L.DomEvent.stopPropagation(e);
+        L.DomEvent.preventDefault(e);
+        toggleFullscreen();
+      });
+      return btn;
+    };
+    fullscreenControl.addTo(map);
     const layer = L.geoJSON(data).addTo(map);
     try {
       map.fitBounds(layer.getBounds());


### PR DESCRIPTION
## Summary
- add map fullscreen styling and control
- allow toggling metadata map between normal and fullscreen views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a163dd2e7483299e2d12a740a4a1d4