### PR TITLE
Fix fullscreen map toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -244,7 +244,7 @@ pre {
   margin: 1em 0;
 }
 
-.map-fullscreen {
+#map.map-fullscreen, #map-offcanvas.map-fullscreen {
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Summary
- Ensure map fullscreen mode overrides height and margin so button works

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a165353a1c8329a01638d51ebf91ec