### PR TITLE
Shrink metadata column width in post view

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -216,6 +216,11 @@ pre {
   overflow-wrap: anywhere;
 }
 
+.metadata-table th {
+  white-space: nowrap;
+  width: 1%;
+}
+
 .dark-mode .table,
 .dark-mode .table th,
 .dark-mode .table td,

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -20,7 +20,7 @@
         {{ toc|safe }}
         {% if metadata or locations or geodata %}
         <h3>{{ _('Common') }}</h3>
-        <table class="table table-sm">
+        <table class="table table-sm metadata-table">
           <tbody>
             {% for key, value in metadata.items() %}
             <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
@@ -51,7 +51,7 @@
         {% endif %}
         {% if user_metadata %}
         <h3>{{ _('Your Metadata') }}</h3>
-        <table class="table table-sm">
+        <table class="table table-sm metadata-table">
           <tbody>
             {% for key, value in user_metadata.items() %}
             <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
@@ -74,7 +74,7 @@
           {{ toc|safe }}
           {% if metadata or locations or geodata %}
           <h3>{{ _('Common') }}</h3>
-          <table class="table table-sm">
+          <table class="table table-sm metadata-table">
             <tbody>
               {% for key, value in metadata.items() %}
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
@@ -105,7 +105,7 @@
           {% endif %}
           {% if user_metadata %}
           <h3>{{ _('Your Metadata') }}</h3>
-          <table class="table table-sm">
+          <table class="table table-sm metadata-table">
             <tbody>
               {% for key, value in user_metadata.items() %}
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
@@ -136,7 +136,7 @@
   <h2>{{ _('Metadata') }}</h2>
   {% if metadata or locations or geodata %}
   <h3>{{ _('Common') }}</h3>
-  <table class="table table-sm">
+  <table class="table table-sm metadata-table">
     <tbody>
       {% for key, value in metadata.items() %}
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
@@ -167,7 +167,7 @@
   {% endif %}
   {% if user_metadata %}
   <h3>{{ _('Your Metadata') }}</h3>
-  <table class="table table-sm">
+  <table class="table table-sm metadata-table">
     <tbody>
       {% for key, value in user_metadata.items() %}
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>

--- a/tests/test_metadata_table.py
+++ b/tests/test_metadata_table.py
@@ -47,6 +47,7 @@ def test_metadata_table_under_toc(client):
     assert '10.0' in nav_html
     assert 'Longitude' in nav_html
     assert '20.0' in nav_html
+    assert 'metadata-table' in nav_html
 
 
 def test_map_and_location_moved_under_toc(client):


### PR DESCRIPTION
## Summary
- add `metadata-table` class to metadata tables and style to reduce label column width
- update metadata table test to ensure new class is present

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a16551f0248329b0d32adeb0089797