### PR TITLE
Refactor citation stats layout

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -3,11 +3,6 @@
 {% block content %}
 <h1>{{ _('Citation Statistics') }}</h1>
   <table class="table citation-table">
-  <tr>
-    <th>{{ _('DOI / Citation') }}</th>
-    <th>{{ _('Usage Count') }}</th>
-    <th>{{ _('Posts') }}</th>
-  </tr>
   {% for item in stats %}
   <tr>
     <td>
@@ -16,8 +11,10 @@
       {% else %}
         <a href="https://scholar.google.com/scholar?q={{ item.citation_text | urlencode }}">{{ item.citation_text }}</a>
       {% endif %}
+      ({{ item.count }})
     </td>
-    <td>{{ item.count }}</td>
+  </tr>
+  <tr>
     <td>
       {% for post in item.posts %}
         <a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a>{% if not loop.last %}, {% endif %}
@@ -25,7 +22,7 @@
     </td>
   </tr>
   {% endfor %}
-</table>
+  </table>
 <nav>
   <ul class="pagination">
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">

--- a/tests/test_citation_stats_pagination.py
+++ b/tests/test_citation_stats_pagination.py
@@ -45,8 +45,8 @@ def test_citation_stats_pagination(client):
 
     resp = client.get('/citations/stats')
     assert resp.status_code == 200
-    assert resp.data.count(b'<tr>') - 1 == 20
+    assert resp.data.count(b'https://doi.org') == 20
 
     resp = client.get('/citations/stats', query_string={'page': 2})
     assert resp.status_code == 200
-    assert resp.data.count(b'<tr>') - 1 == 5
+    assert resp.data.count(b'https://doi.org') == 5


### PR DESCRIPTION
## Summary
- show citation link and count in a single row
- list related posts on a second row
- adjust citation stats pagination test for new markup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a165ced3488329b4e6bede348de56c