### PR TITLE
Preserve explicit numbering in markdown lists

### DIFF
--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -31,6 +31,13 @@ def test_render_markdown_with_toc_headings():
     assert '<a href="#heading">Heading</a>' in toc
 
 
+def test_render_markdown_preserves_list_numbers():
+    html, _ = render_markdown('1. one\n3. three')
+    assert '<li value="1">one</li>' in html
+    assert '<li value="3">three</li>' in html
+    assert 'value="2"' not in html
+
+
 @pytest.fixture
 def client():
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- add a custom markdown extension to respect explicit numbers in ordered lists
- cover non-sequential list numbering with a regression test

## Testing
- `python -m py_compile app.py tests/test_markdown_parser.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a165a1b2108329ade072cc4283f55c