### PR TITLE
Condense citation stats pagination with ellipsis

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -28,11 +28,23 @@
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('citation_stats', page=pagination.prev_num) }}">&laquo;</a>
     </li>
-    {% for p in range(1, pagination.pages + 1) %}
-    <li class="page-item{% if p == pagination.page %} active{% endif %}">
-      <a class="page-link" href="{{ url_for('citation_stats', page=p) }}">{{ p }}</a>
-    </li>
-    {% endfor %}
+    {% if pagination.pages <= 7 %}
+      {% for p in range(1, pagination.pages + 1) %}
+        <li class="page-item{% if p == pagination.page %} active{% endif %}">
+          <a class="page-link" href="{{ url_for('citation_stats', page=p) }}">{{ p }}</a>
+        </li>
+      {% endfor %}
+    {% else %}
+      {% for p in pagination.iter_pages(left_edge=2, right_edge=2, left_current=2, right_current=2) %}
+        {% if p %}
+          <li class="page-item{% if p == pagination.page %} active{% endif %}">
+            <a class="page-link" href="{{ url_for('citation_stats', page=p) }}">{{ p }}</a>
+          </li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">…</span></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('citation_stats', page=pagination.next_num) }}">&raquo;</a>
     </li>


### PR DESCRIPTION
## Summary
- shorten citation statistics pagination and show ellipsis when pages are numerous
- add regression test for pagination truncation

## Testing
- `pytest tests/test_citation_stats_pagination.py tests/test_citation_stats_links.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a167267abc8329ae049ba2194239a5