### PR TITLE
Fix citation link rendering for URL citations

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -8,6 +8,8 @@
     <td>
       {% if item.doi %}
         <a href="https://doi.org/{{ item.doi }}">{{ item.doi }}</a>
+      {% elif item.citation_text.startswith('http://') or item.citation_text.startswith('https://') %}
+        <a href="{{ item.citation_text }}">{{ item.citation_text }}</a>
       {% else %}
         <a href="https://scholar.google.com/scholar?q={{ item.citation_text | urlencode }}">{{ item.citation_text }}</a>
       {% endif %}

--- a/tests/test_citation_stats_links.py
+++ b/tests/test_citation_stats_links.py
@@ -52,6 +52,18 @@ def test_citation_links(client):
                 bibtex_fields={'title': 'title2'},
             )
         )
+        db.session.add(
+            PostCitation(
+                post_id=post.id,
+                user_id=user.id,
+                citation_part={'title': 'title3'},
+                citation_text='https://www.nec.go.kr/portal/bbs/view/B000000000000001?nttId=12345',
+                context='',
+                doi=None,
+                bibtex_raw='@article{c}',
+                bibtex_fields={'title': 'title3'},
+            )
+        )
         db.session.commit()
 
     resp = client.get('/citations/stats')
@@ -59,3 +71,4 @@ def test_citation_links(client):
     html = resp.data.decode('utf-8')
     assert 'href="https://doi.org/10.1000/xyz"' in html
     assert 'href="https://scholar.google.com/scholar?q=No%20DOI"' in html
+    assert 'href="https://www.nec.go.kr/portal/bbs/view/B000000000000001?nttId=12345"' in html


### PR DESCRIPTION
## Summary
- Render citation stats entries with direct links when citation text is a URL instead of defaulting to a Google Scholar search
- Add regression test covering URL citation texts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1676e1d5c83299c05b9ce04cf16bc