### PR TITLE
Exclude deleted posts from tag map

### DIFF
--- a/app.py
+++ b/app.py
@@ -2652,6 +2652,8 @@ def tag_list():
     for tag in tags:
         coords = None
         for p in tag.posts:
+            if not p.title or not p.body:
+                continue
             if p.latitude is not None and p.longitude is not None:
                 coords = (p.latitude, p.longitude)
                 break
@@ -2674,7 +2676,7 @@ def tag_list():
                 }
             )
         top_posts = sorted(
-            [(p, get_view_count(p)) for p in tag.posts],
+            [(p, get_view_count(p)) for p in tag.posts if p.title and p.body],
             key=lambda x: x[1],
             reverse=True,
         )[:3]

--- a/tests/test_tags_map.py
+++ b/tests/test_tags_map.py
@@ -91,3 +91,26 @@ def test_deleted_tag_is_excluded(client):
     resp = client.get('/tags')
     data = resp.get_data(as_text=True)
     assert '[deleted]' not in data
+
+
+def test_tags_page_skips_deleted_posts(client):
+    with app.app_context():
+        user = User.query.filter_by(username='u').first()
+        tag = Tag.query.filter_by(name='t1').first()
+        post = Post(
+            title='Gone',
+            body='body',
+            path='pg',
+            language='en',
+            author_id=user.id,
+            tags=[tag],
+        )
+        db.session.add(post)
+        db.session.commit()
+        post.title = ''
+        post.body = ''
+        db.session.commit()
+    resp = client.get('/tags')
+    data = resp.get_data(as_text=True)
+    assert '/en/pg' not in data
+    assert '[deleted]' not in data


### PR DESCRIPTION
## Summary
- ignore posts without title/body when building tag map
- test that tags page omits deleted posts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a167a1aad48329a6ee6f9c21fe6da5