### PR TITLE
Use async for citation suggestions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ markdown==3.5.1
 python-dotenv==1.0.1
 redis==5.0.0
 requests==2.31.0
+httpx==0.28.1
 tzdata==2025.2


### PR DESCRIPTION
## Summary
- make Crossref citation lookup asynchronous with httpx and an asyncio semaphore
- update citation suggestion routes to await the async helper
- add httpx dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16a7d3a808329a6382d6aec7fb11a