### PR TITLE
Fix map fullscreen button hiding map

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -263,6 +263,10 @@ pre {
   z-index: 2001;
 }
 
+body.map-fullscreen-active {
+  overflow: hidden;
+}
+
 @media (max-width: 600px) {
   #map, #map-offcanvas {
     height: 200px;

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -445,7 +445,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const toggleFullscreen = () => {
       el.classList.toggle('map-fullscreen');
-      document.body.classList.toggle('overflow-hidden');
+      document.body.classList.toggle('map-fullscreen-active');
       setTimeout(() => map.invalidateSize(), 200);
     };
     const fullscreenControl = L.control({position: 'topleft'});


### PR DESCRIPTION
## Summary
- prevent fullscreen map button from removing the map by using a dedicated body class instead of Bootstrap's `overflow-hidden`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a16b0d72948329a8fa02b3533ecb27