### PR TITLE
Adjust tag marker width to fit text

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -46,12 +46,16 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
 function createIcon(name){
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.font = '14px sans-serif';
+  const textWidth = Math.ceil(ctx.measureText(name).width);
+  const width = textWidth + 20;
   const svg = `\
-  <svg xmlns="http://www.w3.org/2000/svg" width="110" height="40">
-    <rect x="5" y="5" width="100" height="30" rx="5" ry="5" fill="#0d6efd" fill-opacity="0.1" stroke-width="0" />
-    <text x="55" y="25" font-size="14" text-anchor="middle" fill="#0d6efd">${name}</text>
+  <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="40">
+    <rect x="5" y="5" width="${width - 10}" height="30" rx="5" ry="5" fill="#0d6efd" fill-opacity="0.1" stroke-width="0" />
+    <text x="${width / 2}" y="25" font-size="14" text-anchor="middle" fill="#0d6efd">${name}</text>
   </svg>`;
-  return L.divIcon({html: svg, className: '', iconSize:[110,40], iconAnchor:[55,40]});
+  return L.divIcon({html: svg, className: '', iconSize:[width,40], iconAnchor:[width/2,40]});
 }
 const markers = L.markerClusterGroup({
   spiderLegPolylineOptions: {


### PR DESCRIPTION
## Summary
- Dynamically size tag map markers based on label width for clearer text spacing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a16b2b63cc832992264d3219ba24a9