### PR TITLE
Display reverse geocoded addresses for coordinates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1650,7 +1650,9 @@ def post_detail(post_id: int):
     locations, warning = extract_locations(post_meta)
     post_lat = post.latitude
     post_lon = post.longitude
+    address = None
     if post_lat is not None and post_lon is not None:
+        address = reverse_geocode_coords(post_lat, post_lon)
         locations = [
             loc
             for loc in locations
@@ -1720,6 +1722,7 @@ def post_detail(post_id: int):
         user_citations=user_citations,
         views=views,
         created_at=created_at,
+        address=address,
     )
 
 
@@ -1815,7 +1818,9 @@ def document(language: str, doc_path: str):
     locations, warning = extract_locations(post_meta)
     post_lat = post.latitude
     post_lon = post.longitude
+    address = None
     if post_lat is not None and post_lon is not None:
+        address = reverse_geocode_coords(post_lat, post_lon)
         locations = [
             loc
             for loc in locations
@@ -1889,6 +1894,7 @@ def document(language: str, doc_path: str):
         user_citations=user_citations,
         views=views,
         created_at=created_at,
+        address=address,
     )
 
 

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -22,14 +22,17 @@
         <h3>{{ _('Common') }}</h3>
         <table class="table table-sm metadata-table">
           <tbody>
-            {% for key, value in metadata.items() %}
-            <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
-            {% endfor %}
-            {% if lat is not none and lon is not none %}
-            <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
-            <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
-            {% endif %}
-            {% if locations %}
+                {% for key, value in metadata.items() %}
+                <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
+                {% endfor %}
+                {% if lat is not none and lon is not none %}
+                {% if address %}
+                <tr><th scope="row">{{ _('Location') }}</th><td>{{ address }} <span class="text-muted">({{ lat }}, {{ lon }})</span></td></tr>
+                {% endif %}
+                <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
+                <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
+                {% endif %}
+                {% if locations %}
               {% for loc in locations %}
               <tr>
                 <th scope="row">{{ _('Location') }}</th>
@@ -80,6 +83,9 @@
               <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
               {% endfor %}
               {% if lat is not none and lon is not none %}
+              {% if address %}
+              <tr><th scope="row">{{ _('Location') }}</th><td>{{ address }} <span class="text-muted">({{ lat }}, {{ lon }})</span></td></tr>
+              {% endif %}
               <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
               <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
               {% endif %}
@@ -142,6 +148,9 @@
       <tr><th scope="row">{{ key }}</th><td>{{ value|format_metadata }}</td></tr>
       {% endfor %}
       {% if lat is not none and lon is not none %}
+      {% if address %}
+      <tr><th scope="row">{{ _('Location') }}</th><td>{{ address }} <span class="text-muted">({{ lat }}, {{ lon }})</span></td></tr>
+      {% endif %}
       <tr><th scope="row">{{ _('Latitude') }}</th><td>{{ lat }}</td></tr>
       <tr><th scope="row">{{ _('Longitude') }}</th><td>{{ lon }}</td></tr>
       {% endif %}

--- a/tests/test_reverse_geocode.py
+++ b/tests/test_reverse_geocode.py
@@ -63,3 +63,19 @@ def test_doc_path_shows_reverse_geocode(client, monkeypatch):
     assert resp.status_code == 302
     resp = client.get('/en/p')
     assert b'Test Place' in resp.data
+
+
+def test_latlon_fields_reverse_geocode(client, monkeypatch):
+    monkeypatch.setattr(app_module, 'reverse_geocode_coords', lambda lat, lon: 'Test Place')
+    with app.app_context():
+        user = User.query.first()
+        post = Post(title='Title', body='Body', path='p2', language='en', author=user)
+        post.latitude = 1.0
+        post.longitude = 2.0
+        db.session.add(post)
+        db.session.commit()
+        post_id = post.id
+    resp = client.get(f'/post/{post_id}')
+    assert b'Test Place' in resp.data
+    resp = client.get('/en/p2')
+    assert b'Test Place' in resp.data


### PR DESCRIPTION
## Summary
- reverse geocode post latitude/longitude to show a human-readable address
- surface the address in metadata tables next to coordinate values
- add tests covering address display for post coordinates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16cd24658832995169802f9567e6a