### PR TITLE
Improve tag marker spacing

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -115,7 +115,8 @@ const markers = L.markerClusterGroup({
     weight: 1,
     opacity: 1
   },
-  maxClusterRadius: 120
+  maxClusterRadius: 120,
+  spiderfyDistanceMultiplier: 2.5
 });
   tagLocations.forEach(t => {
     const marker = L.marker([t.lat, t.lon], {icon: createIcon(t.name)});


### PR DESCRIPTION
## Summary
- increase spiderfy distance for tag markers to reduce overlap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a16faa88988329ace2af3b24ea7ab4