### PR TITLE
Improve recent changes readability

### DIFF
--- a/templates/recent.html
+++ b/templates/recent.html
@@ -2,9 +2,9 @@
 {% block title %}{{ _('Recent changes') }}{% endblock %}
 {% block content %}
 <h1>{{ _('Recent changes') }}</h1>
-<ul class="list-group">
+<ul class="list-group fs-5 mb-3">
     {% for rev in revisions %}
-      <li class="list-group-item">
+      <li class="list-group-item text-break" style="word-break: break-all;">
         {{ rev.created_at|format_datetime('%Y-%m-%d %H:%M %Z') }} -
         <a href="{{ url_for('post_detail', post_id=rev.post_id) }}">{{ rev.title }}</a>
         (<a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ _('diff') }}</a>)
@@ -16,4 +16,5 @@
       <li class="list-group-item">{{ _('No revisions yet.') }}</li>
     {% endfor %}
 </ul>
+<hr>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap long entries and bump font size in recent changes log
- add a separator below the log for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17056f80883298af4237ad9211fdc