### PR TITLE
Randomize citation suggestion queries

### DIFF
--- a/API.md
+++ b/API.md
@@ -284,10 +284,10 @@ Response
 
 ### `/citation/suggest` (`POST`)
 
-Suggest citations for multiple sentences of text. Only the most frequent
-keywords from each sentence are used when querying external services.
-Keyword extraction is language-aware and currently supports Korean, English,
-Japanese, French, German and Chinese.
+Suggest citations for multiple sentences of text. A random selection of two or
+three words from each sentence is used when querying external services.
+Language detection uses the full sentence and currently supports Korean,
+English, Japanese, French, German and Chinese.
 
 **Parameters**
 
@@ -316,8 +316,8 @@ Response
 
 ### `/citation/suggest_line` (`POST`)
 
-Like `/citation/suggest` but processes one line at a time, extracting the
-most frequent words from that line to build the search query.
+Like `/citation/suggest` but processes one line at a time, selecting two or
+three random words from that line to build the search query.
 
 **Parameters**
 

--- a/tests/test_citation_suggest.py
+++ b/tests/test_citation_suggest.py
@@ -20,10 +20,12 @@ def test_suggest_citations_multiword(monkeypatch):
 
     monkeypatch.setattr(app.cr, 'works', fake_works)
     monkeypatch.setattr(app.requests, 'get', fake_get)
+    monkeypatch.setattr(app.random, 'choice', lambda seq: 3)
+    monkeypatch.setattr(app.random, 'sample', lambda seq, k: ['quick', 'fox', 'dog'])
 
     results = app.suggest_citations(sentence)
     assert sentence in results
-    assert captured['kwargs']['query_bibliographic'] == sentence
+    assert captured['kwargs']['query_bibliographic'] == 'quick fox dog'
     assert captured['kwargs']['query_language'] == 'en'
 
 
@@ -36,8 +38,10 @@ def test_suggest_citations_multilingual(monkeypatch):
         return {'message': {'items': []}}
 
     monkeypatch.setattr(app.cr, 'works', fake_works)
+    monkeypatch.setattr(app.random, 'choice', lambda seq: 2)
+    monkeypatch.setattr(app.random, 'sample', lambda seq, k: ['science', 'avance'])
 
     results = app.suggest_citations(sentence)
     assert results == {}
-    assert captured['kwargs']['query_bibliographic'] == sentence
+    assert captured['kwargs']['query_bibliographic'] == 'science avance'
     assert captured['kwargs']['query_language'] == 'fr'


### PR DESCRIPTION
## Summary
- Use 2–3 random words from each sentence when querying Crossref for citation suggestions
- Update tests and API docs for the randomized citation lookup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a171d89918832998761c954e6fd93b