### PR TITLE
Widen post layout and table of contents

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -127,12 +127,16 @@ textarea::placeholder,
   opacity: 0.7;
 }
 
+.content-container {
+  max-width: 1500px;
+}
+
 .toc-container {
   border: 1px solid var(--border-color);
   padding: 10px;
   margin-right: 20px;
   background: var(--toc-bg-color);
-  min-width: 200px;
+  min-width: 280px;
 }
 
 .toc-container.sticky-top {

--- a/templates/base.html
+++ b/templates/base.html
@@ -90,7 +90,7 @@
     window.hideSpinner = hideSpinner;
   })();
 </script>
-<div class="container mt-4">
+<div class="container content-container mt-4">
 {% with messages = get_flashed_messages() %}
   {% if messages %}
     {% for message in messages %}

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -13,7 +13,7 @@
 <p><small>{{ post.path }}</small></p>
 <div class="row">
   {% if toc %}
-  <div class="col-md-3">
+  <div class="col-md-4">
     <div class="d-none d-md-block">
       <nav class="toc-container sticky-top">
         <h2>{{ _('Contents') }}</h2>
@@ -123,7 +123,7 @@
       </div>
     </div>
   </div>
-  <div class="col-md-9">
+  <div class="col-md-8">
     <div class="post-body">{{ html_body|safe }}</div>
   </div>
   {% else %}


### PR DESCRIPTION
## Summary
- Allow main content container to span wider screens
- Increase TOC column and minimum width for better readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a171f9e5148329a431e67d5b38eee3