### PR TITLE
Style view logs on recent changes page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -199,6 +199,15 @@ pre {
   width: 100%;
 }
 
+.view-log {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  margin-right: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.25rem;
+  background-color: var(--toc-bg-color);
+}
+
 .citation-table th:first-child,
 .citation-table td:first-child {
   width: 45%;

--- a/templates/recent.html
+++ b/templates/recent.html
@@ -5,7 +5,7 @@
 <ul class="list-group fs-5 mb-3">
     {% for rev in revisions %}
       <li class="list-group-item text-break" style="word-break: break-all;">
-        {{ rev.created_at|format_datetime('%Y-%m-%d %H:%M %Z') }} -
+        <span class="view-log">[{{ rev.created_at|format_datetime('%Y-%m-%d %H:%M %Z') }}]</span>
         <a href="{{ url_for('post_detail', post_id=rev.post_id) }}">{{ rev.title }}</a>
         (<a href="{{ url_for('revision_diff', post_id=rev.post_id, rev_id=rev.id) }}">{{ _('diff') }}</a>)
         {{ _('by') }} <a href="{{ url_for('profile', username=rev.user.username) }}">{{ rev.user.username }}</a>


### PR DESCRIPTION
## Summary
- Wrap revision timestamps in a styled `view-log` badge on the recent changes page
- Add reusable `.view-log` CSS class with rounded corners and subtle background

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a174d32b80832995d8c9548b837eae