### PR TITLE
style: tweak toc and tag appearance

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -132,10 +132,11 @@ textarea::placeholder,
 }
 
 .toc-container {
-  border: 1px solid var(--border-color);
+  border: none;
+  border-right: 1px solid var(--border-color);
   padding: 10px;
   margin-right: 20px;
-  background: var(--toc-bg-color);
+  background: transparent;
   min-width: 280px;
 }
 
@@ -310,6 +311,23 @@ body.map-fullscreen-active {
 
 .tag-card h5 {
   margin: 0 0 0.5rem 0;
+}
+
+.tag-pill {
+  display: inline-block;
+  padding: 0.1rem 0.6rem;
+  margin-right: 0.25rem;
+  background-color: var(--nav-bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 50rem;
+  color: var(--text-color);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.tag-pill:hover {
+  background-color: var(--toc-bg-color);
+  text-decoration: none;
 }
 
 footer {

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -134,7 +134,7 @@
 </div>
 <p>{{ _('Tags') }}:
   {% for tag in post.tags %}
-    <a href="{{ url_for('tag_filter', name=tag.name) }}">{{ tag.name }}</a>
+    <a href="{{ url_for('tag_filter', name=tag.name) }}" class="tag-pill">{{ tag.name }}</a>
   {% endfor %}
 </p>
 {% if not toc and (metadata or user_metadata or locations or geodata) %}


### PR DESCRIPTION
## Summary
- Make TOC background transparent with only right border
- Display tags as pill-style links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1755daf0883298edb1877a77994ac