### PR TITLE
Add print stylesheet for printable pages

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -1,0 +1,44 @@
+/* Print-specific styles */
+
+/* Basic layout for print */
+body {
+  background: #fff;
+  color: #000;
+  font-size: 12pt;
+  margin: 0;
+}
+
+/* Hide navigation and interactive elements */
+.navbar,
+#spinner-overlay,
+#theme-toggle,
+#reading-breadcrumb,
+.btn,
+.dropdown-menu,
+.offcanvas,
+.pagination {
+  display: none !important;
+}
+
+/* Ensure content tables are full width */
+.metadata-table,
+.citation-table {
+  width: 100%;
+  font-size: 10pt;
+}
+
+/* Map sizing for print */
+#map,
+#map-offcanvas,
+#map-modal {
+  height: 300px;
+  width: 100%;
+}
+
+/* Quote styling */
+blockquote {
+  border-left: 3px solid #ccc;
+  padding-left: 1em;
+  margin-left: 0;
+  font-style: italic;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}" media="print">
   {{ get_setting('head_tags')|safe }}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add dedicated `print.css` loaded only when printing
- style metadata, map and citations for better printed layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17935403c832980714bd8b5931201