### PR TITLE
Increase spiderfy distance for tag map

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -135,7 +135,8 @@ const markers = L.markerClusterGroup({
     opacity: 1
   },
   maxClusterRadius: 120,
-  spiderfyDistanceMultiplier: 2.5,
+  // Increase spiderfy distance so large tag icons do not overlap
+  spiderfyDistanceMultiplier: 3.5,
   iconCreateFunction: function(cluster){
     const count = cluster.getChildCount();
     let c = ' marker-cluster-small';


### PR DESCRIPTION
## Summary
- Spread spiderfied tag markers farther apart to avoid overlapping custom icons

## Testing
- ⚠️ `pytest` (hung, terminated)
- ✅ `pytest tests/test_coordinates.py`
- ✅ `pytest tests/test_citation_suggest.py`
- ✅ `pytest tests/test_tags_map.py`
- ✅ `pytest tests/test_profile_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68a178a7c2c483298af4fc455fafe806