### PR TITLE
Default to dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -215,7 +215,7 @@
 </script>
 <script>
   const storedTheme = localStorage.getItem('theme');
-  if (storedTheme === 'dark') {
+  if (storedTheme !== 'light') {
     document.body.classList.add('dark-mode');
   }
   document.getElementById('theme-toggle').addEventListener('click', () => {

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -451,7 +451,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const data = { type: 'FeatureCollection', features: {{ geodata|tojson }} };
   const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
   const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-  const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
+  const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') !== 'light';
 
   function initMap(el) {
     const map = L.map(el).setView([0, 0], 2);

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -151,7 +151,7 @@ updatePreview();
 const map = L.map('map').setView([0, 0], 2);
 const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
 const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
+const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') !== 'light';
 const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
   attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);


### PR DESCRIPTION
## Summary
- Default to dark theme when no preference is stored
- Ensure map tiles respect dark mode by default

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17a751d80832980629326c1b7bfbc