### PR TITLE
Hide citation form when printing

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -221,11 +221,11 @@
 </section>
 {% endif %}
 {% if current_user.is_authenticated %}
-<section>
+<section class="d-print-none">
   <h2>{{ _('Suggest Citation') }}</h2>
   <p>{{ _('Use the buttons next to each paragraph to get suggestions.') }}</p>
 </section>
-<section>
+<section class="d-print-none">
   <h2>{{ _('Add Citation') }}</h2>
   <form id="citation-form" action="{{ url_for('new_citation', post_id=post.id) }}" method="post">
     <div class="mb-2 d-flex gap-1">


### PR DESCRIPTION
## Summary
- hide the "Suggest Citation" and "Add Citation" sections in print mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17ab7aed88329ade4528fb3300b7c