### PR TITLE
Keep maps in default style regardless of theme

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -449,23 +449,13 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script>
   const data = { type: 'FeatureCollection', features: {{ geodata|tojson }} };
-  const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
-  const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-  const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
 
   function initMap(el) {
     const map = L.map(el).setView([0, 0], 2);
-    const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
-    const updateTiles = () => {
-        tiles.setUrl(isDark() ? darkUrl : lightUrl);
-    };
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-        themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
-    }
     const layer = L.geoJSON(data).addTo(map);
     try {
       map.fitBounds(layer.getBounds());

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -149,19 +149,9 @@ document.querySelectorAll('input[name="language"]').forEach(el => {
 updatePreview();
 
 const map = L.map('map').setView([0, 0], 2);
-const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
-const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') === 'dark';
-const tiles = L.tileLayer(isDark() ? darkUrl : lightUrl, {
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
-const updateTiles = () => {
-  tiles.setUrl(isDark() ? darkUrl : lightUrl);
-};
-const themeToggle = document.getElementById('theme-toggle');
-if (themeToggle) {
-  themeToggle.addEventListener('click', () => setTimeout(updateTiles, 0));
-}
 const drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 const drawControl = new L.Control.Draw({


### PR DESCRIPTION
## Summary
- Remove dark-mode switching for Leaflet tiles so maps always use default OpenStreetMap style
- Simplify map setup in post form and detail pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a179e360e08329b29e3364cddbc6f5