### PR TITLE
Fix dark mode view log clear button visibility

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -91,6 +91,11 @@ nav a {
   color: var(--text-color);
 }
 
+/* Ensure close buttons remain visible in dark mode */
+.dark-mode .btn-close {
+  filter: invert(1);
+}
+
 .list-group-item {
   background-color: var(--background-color) !important;
   color: var(--text-color) !important;


### PR DESCRIPTION
## Summary
- Ensure `btn-close` elements invert color in dark mode so view log clear buttons stay visible

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17d4b74c88329838ffc28d2fd5d3b