### PR TITLE
Show timezone and improve dark-mode readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -1011,16 +1011,24 @@ def normalize_timezone(tz: str) -> str | None:
 
 
 @app.template_filter('format_datetime')
-def format_datetime(value: datetime, fmt: str = '%Y-%m-%d %H:%M') -> str:
+def format_datetime(value: datetime, fmt: str = '%Y-%m-%d %H:%M %Z') -> str:
     tz_name = get_user_timezone()
     try:
         tzinfo = ZoneInfo(tz_name)
     except ZoneInfoNotFoundError:
         tzinfo = timezone.utc
+        tz_name = 'UTC'
     dt = value
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(tzinfo).strftime(fmt)
+    local_dt = dt.astimezone(tzinfo)
+    formatted = local_dt.strftime(fmt)
+    abbr = local_dt.strftime('%Z')
+    if '%Z' not in fmt:
+        formatted = f"{formatted} {abbr}"
+    if tz_name != abbr:
+        formatted = f"{formatted} ({tz_name})"
+    return formatted
 
 
 @app.context_processor

--- a/static/style.css
+++ b/static/style.css
@@ -44,6 +44,11 @@ html, body {
   --navbar-toggler-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255, 255, 255, 0.55)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
+/* Ensure muted text remains visible in dark mode */
+.dark-mode .text-muted {
+  color: #b3b3b3 !important;
+}
+
 body {
   font-family: Arial, sans-serif;
   padding: 20px;


### PR DESCRIPTION
## Summary
- Ensure timestamps always display timezone information
- Improve visibility of muted text in dark mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17eb7411c832998780d27732990d1