### PR TITLE
Display tag cards below map

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -32,6 +32,25 @@
   <div id="tag-info-content" class="p-3"></div>
 </div>
 <div id="tag-map"></div>
+<div class="container mt-4">
+  {% for info in tag_info %}
+    <div class="tag-card">
+      <h5>
+        <a href="{{ url_for('tag_filter', name=info.tag.name) }}" class="tag-pill">{{ info.tag.name }}</a>
+      </h5>
+      {% if info.top_posts %}
+        <ul>
+          {% for post, views in info.top_posts %}
+            <li>
+              <a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a>
+              <span class="small text-muted">· {{ views }} {{ _('views') }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  {% endfor %}
+</div>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- Render tag list below map using `.tag-card` and `.tag-pill` classes
- Link each tag name to its filter page and show top posts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1a75a9e408329a942b05d546ae6fd