### PR TITLE
Add fallback for missing Markdown editor

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -87,7 +87,13 @@
 <script src="https://cdn.jsdelivr.net/npm/jsoneditor@9/dist/jsoneditor.min.js"></script>
 <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 <script>
-const easyMDE = new EasyMDE({ element: document.getElementById('body') });
+const bodyEl = document.getElementById('body');
+let easyMDE;
+try {
+  easyMDE = new EasyMDE({ element: bodyEl });
+} catch (e) {
+  console.error(e);
+}
 const previewEl = document.getElementById('preview');
 const formEl = document.getElementById('post-form');
 formEl.addEventListener('keydown', function (e) {
@@ -134,7 +140,7 @@ function updatePreview() {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({
-      text: easyMDE.value(),
+      text: easyMDE ? easyMDE.value() : bodyEl.value,
       language: document.querySelector('input[name="language"]:checked').value
     }),
     noSpinner: true
@@ -142,7 +148,11 @@ function updatePreview() {
     previewEl.innerHTML = data.html || '';
   });
 }
-easyMDE.codemirror.on('change', updatePreview);
+if (easyMDE && easyMDE.codemirror) {
+  easyMDE.codemirror.on('change', updatePreview);
+} else {
+  bodyEl.addEventListener('input', updatePreview);
+}
 document.querySelectorAll('input[name="language"]').forEach(el => {
   el.addEventListener('change', updatePreview);
 });

--- a/tests/test_editor_fallback.py
+++ b/tests/test_editor_fallback.py
@@ -1,0 +1,8 @@
+import os
+
+def test_post_form_fallback_present():
+    template_path = os.path.join('templates', 'post_form.html')
+    with open(template_path) as f:
+        content = f.read()
+    assert 'easyMDE ? easyMDE.value() : bodyEl.value' in content
+    assert "bodyEl.addEventListener('input', updatePreview)" in content


### PR DESCRIPTION
## Summary
- Ensure post editor falls back to textarea when EasyMDE fails to load
- Update markdown preview to work with or without EasyMDE
- Test that the fallback logic is present in the post form template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b74b1790832991eaf7a922d9cbae