### PR TITLE
Use internal wiki for citation suggestions

### DIFF
--- a/API.md
+++ b/API.md
@@ -284,10 +284,9 @@ Response
 
 ### `/citation/suggest` (`POST`)
 
-Suggest citations for multiple sentences of text. A random selection of two or
-three words from each sentence is used when querying external services.
-Language detection uses the full sentence and currently supports Korean,
-English, Japanese, French, German and Chinese.
+Suggest citations for multiple sentences of text using existing wiki pages.
+The longest unique words from each sentence query the internal full-text
+search index. Language detection is used to match posts in the same language.
 
 **Parameters**
 
@@ -308,7 +307,7 @@ Response
 {
   "results": {
     "Albert Einstein was born in Ulm.": [
-      {"text": "@article{...}", "part": {"title": "...", "doi": "10.1000/xyz"}}
+      {"text": "@misc{,\n  title={Einstein},\n  url={/en/einstein}\n}", "part": {"title": "Einstein", "url": "/en/einstein"}}
     ]
   }
 }
@@ -316,8 +315,8 @@ Response
 
 ### `/citation/suggest_line` (`POST`)
 
-Like `/citation/suggest` but processes one line at a time, selecting two or
-three random words from that line to build the search query.
+Like `/citation/suggest` but processes one line at a time, using the longest
+words from that line to build the search query.
 
 **Parameters**
 
@@ -338,7 +337,7 @@ Response
 {
   "results": {
     "Quantum mechanics revolutionised physics.": [
-      {"text": "@article{...}", "part": {"title": "...", "doi": "10.1000/abc"}}
+      {"text": "@misc{,\n  title={Quantum mechanics},\n  url={/en/quantum}\n}", "part": {"title": "Quantum mechanics", "url": "/en/quantum"}}
     ]
   }
 }

--- a/tests/test_citation_suggest.py
+++ b/tests/test_citation_suggest.py
@@ -1,98 +1,43 @@
 import os
 import sys
 import pytest
-from types import SimpleNamespace
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import app
+from app import db, User, Post
 
 
-def test_suggest_citations_multiword(monkeypatch):
-    sentence = "The quick brown fox jumps over the lazy dog"
-    captured = {"calls": []}
-
-    def fake_works(**kwargs):
-        captured["calls"].append(kwargs)
-        # Return no results when queried with the full sentence to trigger the
-        # fallback behaviour.
-        if kwargs["query_bibliographic"] == sentence:
-            return {"message": {"items": []}}
-        # The fallback query should use the longest unique words.
-        assert kwargs["query_bibliographic"] == "quick brown jumps"
-        return {"message": {"items": [{"DOI": "10.1234/abc"}]}}
-
-    def fake_get(url, timeout=10):
-        return SimpleNamespace(status_code=200, text="@article{a,title={T}}")
-
-    monkeypatch.setattr(app.cr, "works", fake_works)
-    monkeypatch.setattr(app.requests, "get", fake_get)
-
-    results = app.suggest_citations(sentence)
-    assert sentence in results
-    # Ensure two calls were made: full sentence then fallback sample words
-    assert captured["calls"][1]["query_bibliographic"] == "quick brown jumps"
-    assert captured["calls"][1]["query_language"] == "en"
+@pytest.fixture
+def app_ctx():
+    app.app.config['TESTING'] = True
+    app.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app.app_context():
+        db.create_all()
+        user = User(username='author', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        yield app
+        db.session.remove()
+        db.drop_all()
 
 
-@pytest.mark.parametrize(
-    "sentence,lang",
-    [
-        ("The quick brown fox jumps over the lazy dog.", "en"),
-        ("빠른 갈색 여우가 게으른 개를 뛰어넘는다.", "ko"),
-        ("素早い茶色の狐が怠惰な犬を飛び越える。", "ja"),
-        ("La science avance rapidement.", "fr"),
-        ("Der schnelle braune Fuchs springt über den faulen Hund.", "de"),
-    ],
-)
-def test_suggest_citations_detects_language(monkeypatch, sentence, lang):
-    captured = {}
+def test_suggest_citations_internal(app_ctx):
+    with app_ctx.app.app_context():
+        post = Post(
+            title='Quantum mechanics',
+            body='Quantum mechanics studies matter at small scales.',
+            path='quantum',
+            language='en',
+            author_id=1,
+        )
+        db.session.add(post)
+        db.session.commit()
 
-    def fake_works(**kwargs):
-        captured["kwargs"] = kwargs
-        return {"message": {"items": []}}
+        text = 'Quantum mechanics covers interesting topics.'
+        results = app_ctx.suggest_citations(text)
+        assert text in results
+        cand = results[text][0]['text']
+        assert 'Quantum mechanics' in cand
+        assert '/en/quantum' in cand
 
-    monkeypatch.setattr(app.cr, "works", fake_works)
-
-    results = app.suggest_citations(sentence)
-    assert results == {}
-    assert captured["kwargs"]["query_language"] == lang
-
-
-def test_suggest_citations_full_sentence_first(monkeypatch):
-    sentence = "Deep learning for cats"
-    captured = {"calls": []}
-
-    def fake_works(**kwargs):
-        captured["calls"].append(kwargs)
-        if kwargs["query_bibliographic"] == sentence:
-            # Simulate a successful lookup only when the full sentence is used
-            return {"message": {"items": [{"DOI": "10.1234/xyz"}]}}
-        return {"message": {"items": []}}
-
-    def fake_get(url, timeout=10):
-        return SimpleNamespace(status_code=200, text="@article{a,title={T}}")
-
-    monkeypatch.setattr(app.cr, "works", fake_works)
-    monkeypatch.setattr(app.requests, "get", fake_get)
-
-    results = app.suggest_citations(sentence)
-    # Ensure the first call used the full sentence
-    assert captured["calls"][0]["query_bibliographic"] == sentence
-    assert sentence in results
-
-
-def test_suggest_citations_removes_stopwords(monkeypatch):
-    sentence = "Because because because cat dog"
-    captured = {"calls": []}
-
-    def fake_works(**kwargs):
-        captured["calls"].append(kwargs)
-        return {"message": {"items": []}}
-
-    monkeypatch.setattr(app.cr, "works", fake_works)
-
-    results = app.suggest_citations(sentence)
-    assert results == {}
-    # Second call should remove the stopword "because" and only query with
-    # meaningful terms.
-    assert captured["calls"][1]["query_bibliographic"] == "cat dog"


### PR DESCRIPTION
## Summary
- replace Crossref-based citation suggestions with internal wiki search
- document new citation suggestion behavior in API reference
- test wiki-backed citation suggestions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a268c3fc208329a5aaaa585a388b5a