### PR TITLE
Add standalone search index server with SQLite FTS5

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ Open browser at `http://${HOST}:${PORT}/` or `https://${HOST}:${PORT}/` when SSL
 
 See [API.md](API.md) for a list of HTTP endpoints.
 
+## Search Index Service
+
+A lightweight full-text search service is provided in `index_server.py`. It
+uses SQLite FTS5 and exposes several HTTP endpoints:
+
+- `POST /index` – index or update a document using JSON payload
+  `{id, title, body}`.
+- `DELETE /index/<id>` – remove a document from the index.
+- `GET /search?q=…` – return a JSON array of matching document identifiers.
+- `GET /health` – basic health check endpoint.
+
+Run the service directly with:
+
+```bash
+python index_server.py
+```
+
+For production, multiple instances can be launched behind a load balancer.
+Because the service is stateless aside from the SQLite database file, each
+instance can point to the same database on shared storage. Example using
+`gunicorn` with four workers:
+
+```bash
+gunicorn -w 4 -b 0.0.0.0:8000 index_server:app
+```
+
+Use a load balancer such as Nginx or HAProxy to distribute requests across
+instances running on different ports or hosts.
+
 ## Testing
 
 Run the test suite with [pytest](https://docs.pytest.org/):

--- a/index_server.py
+++ b/index_server.py
@@ -1,0 +1,58 @@
+from flask import Flask, request, jsonify
+import sqlite3
+import threading
+
+app = Flask(__name__)
+
+def get_db():
+    # Lazily create a thread-local connection
+    if not hasattr(app, 'db'):  # but thread safe? We can store thread-local connections
+        app.db = threading.local()
+    if getattr(app.db, 'conn', None) is None:
+        app.db.conn = sqlite3.connect('search.db', check_same_thread=False)
+        app.db.conn.execute(
+            'CREATE VIRTUAL TABLE IF NOT EXISTS documents '
+            'USING fts5(id, title, body)'
+        )
+    return app.db.conn
+
+@app.route('/index', methods=['POST'])
+def index_document():
+    data = request.get_json(force=True)
+    doc_id = data.get('id')
+    title = data.get('title', '')
+    body = data.get('body', '')
+    if doc_id is None:
+        return jsonify({'error': 'id is required'}), 400
+    conn = get_db()
+    with conn:
+        conn.execute('DELETE FROM documents WHERE id = ?', (doc_id,))
+        conn.execute(
+            'INSERT INTO documents (id, title, body) VALUES (?, ?, ?)',
+            (doc_id, title, body)
+        )
+    return jsonify({'status': 'indexed'})
+
+@app.route('/index/<doc_id>', methods=['DELETE'])
+def delete_document(doc_id):
+    conn = get_db()
+    with conn:
+        conn.execute('DELETE FROM documents WHERE id = ?', (doc_id,))
+    return jsonify({'status': 'deleted'})
+
+@app.route('/search')
+def search():
+    query = request.args.get('q')
+    if not query:
+        return jsonify({'error': 'q parameter is required'}), 400
+    conn = get_db()
+    cur = conn.execute('SELECT id FROM documents WHERE documents MATCH ?', (query,))
+    results = [row[0] for row in cur.fetchall()]
+    return jsonify(results)
+
+@app.route('/health')
+def health():
+    return jsonify({'status': 'ok'})
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- add `index_server.py` providing REST endpoints for indexing, deleting, searching, and health checks using SQLite FTS5
- document search index service and scaling behind a load balancer in `README.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27ef5464c832997bee20c4279607b