### PR TITLE
Add INDEX_SERVER_URL configuration option

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,13 @@
 
 This document lists the HTTP endpoints provided by the Spacetime application.
 
+## Configuration
+
+The application reads the following setting from environment variables or
+configuration files:
+
+- `INDEX_SERVER_URL` – base URL for an optional external index server (default: none).
+
 | Path | Methods | Description |
 |------|---------|-------------|
 | `/` | `GET` | Home page listing posts or redirect to configured start page |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ following variables are supported:
 - `BABEL_DEFAULT_LOCALE` – default locale for translations.
 - `LANGUAGES` – comma-separated list of supported languages.
 - `BABEL_TRANSLATION_DIRECTORIES` – path to translation files.
+- `INDEX_SERVER_URL` – base URL for an optional external index server (default: none).
 - `HOST` – hostname or IP address for the server.
 - `PORT` – port for the server.
 - `SSL_CERT_FILE` – path to a PEM-formatted certificate file to enable HTTPS.
@@ -41,6 +42,7 @@ SQLALCHEMY_DATABASE_URI=sqlite:///wiki.db
 BABEL_DEFAULT_LOCALE=en
 LANGUAGES=en,es
 BABEL_TRANSLATION_DIRECTORIES=translations
+INDEX_SERVER_URL=https://index.example.com
 HOST=127.0.0.1
 PORT=5000
 SSL_CERT_FILE=cert.pem

--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ app.config['LANGUAGES'] = [
 app.config['BABEL_TRANSLATION_DIRECTORIES'] = os.getenv(
     'BABEL_TRANSLATION_DIRECTORIES', 'translations'
 )
+app.config['INDEX_SERVER_URL'] = os.getenv('INDEX_SERVER_URL', None)
 
 db = SQLAlchemy(app)
 login_manager = LoginManager(app)


### PR DESCRIPTION
## Summary
- allow configuration of optional index server via `INDEX_SERVER_URL`
- document `INDEX_SERVER_URL` in README and API docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27ef6ec9c8329a4894f8075fb8a3b