### PR TITLE
Use external index server for search with fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -2730,14 +2730,34 @@ def search():
     posts_query = None
     examples = None
     if q:
-        ids = [
-            row[0]
-            for row in db.session.execute(
-                text('SELECT rowid FROM post_fts WHERE post_fts MATCH :q'),
-                {'q': q},
+        index_url = os.getenv('INDEX_SERVER_URL')
+        if index_url:
+            try:
+                resp = requests.get(f"{index_url}/search", params={'q': q})
+                resp.raise_for_status()
+                data = resp.json()
+                ids = data.get('ids') if isinstance(data, dict) else data
+                posts_query = (
+                    Post.query.filter(Post.id.in_(ids))
+                    if ids
+                    else Post.query.filter(False)
+                )
+            except requests.RequestException as exc:
+                current_app.logger.warning('Index server search failed: %s', exc)
+                flash(_('Search service unavailable. Showing local results.'), 'warning')
+        if posts_query is None:
+            ids = [
+                row[0]
+                for row in db.session.execute(
+                    text('SELECT rowid FROM post_fts WHERE post_fts MATCH :q'),
+                    {'q': q},
+                )
+            ]
+            posts_query = (
+                Post.query.filter(Post.id.in_(ids))
+                if ids
+                else Post.query.filter(False)
             )
-        ]
-        posts_query = Post.query.filter(Post.id.in_(ids)) if ids else Post.query.filter(False)
     elif key and value_raw:
         try:
             value = json.loads(value_raw)

--- a/tests/test_search_index_server.py
+++ b/tests/test_search_index_server.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+import pytest
+import requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Tag
+from sqlalchemy import text
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.drop_all()
+        db.session.execute(text('DROP TABLE IF EXISTS post_fts'))
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        t1 = Tag(name='news')
+        t2 = Tag(name='science')
+        db.session.add_all([user, t1, t2])
+        db.session.commit()
+        p1 = Post(title='Apple', body='apple banana', path='p1', language='en', author_id=user.id)
+        p1.tags.append(t1)
+        p2 = Post(title='Banana', body='banana carrot', path='p2', language='en', author_id=user.id)
+        p2.tags.append(t2)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+        db.session.execute(text('DROP TABLE IF EXISTS post_fts'))
+
+
+def test_remote_search_success(client, monkeypatch):
+    with app.app_context():
+        banana = Post.query.filter_by(title='Banana').first()
+    class FakeResponse:
+        status_code = 200
+        def json(self):
+            return {'ids': [banana.id]}
+        def raise_for_status(self):
+            pass
+    monkeypatch.setenv('INDEX_SERVER_URL', 'http://index')
+    monkeypatch.setattr(requests, 'get', lambda url, params: FakeResponse())
+    resp = client.get('/search', query_string={'q': 'apple'})
+    text_resp = resp.get_data(as_text=True)
+    assert 'Banana' in text_resp
+    assert 'Apple' not in text_resp
+
+
+def test_remote_search_failure_fallback(client, monkeypatch):
+    def fake_get(url, params):
+        raise requests.RequestException('boom')
+    monkeypatch.setenv('INDEX_SERVER_URL', 'http://index')
+    monkeypatch.setattr(requests, 'get', fake_get)
+    resp = client.get('/search', query_string={'q': 'apple'})
+    text_resp = resp.get_data(as_text=True)
+    assert 'Apple' in text_resp
+    assert 'Search service unavailable' in text_resp


### PR DESCRIPTION
## Summary
- Try hitting an external index server for search queries
- Fall back to local FTS and warn users if the index request fails
- Test remote search success and failure scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a27ef879748329ade226481927cff9