### PR TITLE
Integrate external index server with Post events

### DIFF
--- a/search_index.py
+++ b/search_index.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+
+def send_to_index(post: "Post") -> None:
+    """Send a document to the external index server."""
+    index_url = os.getenv("INDEX_SERVER_URL")
+    if not index_url:
+        return
+    try:
+        resp = requests.post(
+            f"{index_url}/index",
+            json={"id": post.id, "title": post.title, "body": post.body},
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        pass
+
+
+def remove_from_index(post_id: int) -> None:
+    """Remove a document from the external index server."""
+    index_url = os.getenv("INDEX_SERVER_URL")
+    if not index_url:
+        return
+    try:
+        resp = requests.delete(f"{index_url}/index/{post_id}")
+        resp.raise_for_status()
+    except requests.RequestException:
+        pass
+


### PR DESCRIPTION
## Summary
- Add `send_to_index` and `remove_from_index` helpers to interact with optional index server
- Hook Post model events to automatically index or remove documents
- Test that saves and deletes issue correct HTTP requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a28904fb148329902c00f4cf216167