### PR TITLE
Add geospatial search to index server

### DIFF
--- a/docs/INDEX_SERVER.md
+++ b/docs/INDEX_SERVER.md
@@ -1,19 +1,19 @@
 # Index Server
 
 The index server (`index_server.py`) provides a small HTTP service for full-text
-search. It uses [Flask](https://flask.palletsprojects.com/) and a SQLite
-[FTS5](https://sqlite.org/fts5.html) virtual table to store and query
-documents.
+search and geographic lookups. It uses [Flask](https://flask.palletsprojects.com/)
+and a SQLite [FTS5](https://sqlite.org/fts5.html) virtual table together with an
+R-tree for location indexing.
 
 ## Database
 
 A single SQLite database file named `search.db` sits alongside the server. When
-the server starts it ensures a table called `documents` exists with the
-following columns:
+the server starts it ensures the following tables exist:
 
-- `id` – unique identifier for the document (primary key)
-- `title` – title text used during search
-- `body` – full document body used for matching
+- `documents` – FTS5 table with columns `id`, `title`, `body`, `metadata`
+- `tags` – table linking document ids to tags
+- `locations` – table storing `id`, `lat`, and `lon`
+- `locations_rtree` – R-tree virtual table on latitude/longitude for fast range queries
 
 Connections are stored in a thread-local object so that each request handler can
 safely reuse a connection. Each connection is created with
@@ -24,13 +24,16 @@ safely reuse a connection. Each connection is created with
 ### `POST /index`
 
 Index or update a document. The request body must be JSON with at least the
-field `id` and optional `title` and `body` fields:
+field `id` and optional `title`, `body`, `lat`, `lon`, `metadata`, and `tags`
+fields:
 
 ```json
 {
   "id": "123",
   "title": "Example",
-  "body": "Document text"
+  "body": "Document text",
+  "lat": 10.0,
+  "lon": 20.0
 }
 ```
 
@@ -42,11 +45,16 @@ If a document with the same `id` already exists it is replaced. The response is
 Remove the document identified by `id` from the database. The response is
 `{"status": "deleted"}` even if the document was not present.
 
-### `GET /search?q=<term>`
+### `GET /search`
 
-Search for documents containing the query term. The query string parameter `q`
-is required and may contain any valid FTS5 query. The response is a JSON array
-of matching document identifiers:
+Search for documents. Optional query parameters include:
+
+- `q` – FTS5 search query
+- `metadata.KEY` – filter by metadata value
+- `lat`, `lon`, `radius` – return only documents whose stored location falls
+  within `radius` kilometers of the provided latitude and longitude
+
+The response is a JSON array of matching document identifiers:
 
 ```json
 ["123", "456"]
@@ -80,9 +88,13 @@ Index a document and perform a search using `curl`:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
-  -d '{"id":"1","title":"Hello","body":"Hello world"}' \
+  -d '{"id":"1","title":"Hello","body":"Hello world","lat":10,"lon":10}' \
   http://localhost:8000/index
 
+# full-text search
 curl "http://localhost:8000/search?q=hello"
+
+# location search within 500km of 10,10
+curl "http://localhost:8000/search?lat=10&lon=10&radius=500"
 ```
 

--- a/search_index.py
+++ b/search_index.py
@@ -14,7 +14,13 @@ def send_to_index(post: "Post") -> None:
     try:
         resp = requests.post(
             f"{index_url}/index",
-            json={"id": post.id, "title": post.title, "body": post.body},
+            json={
+                "id": post.id,
+                "title": post.title,
+                "body": post.body,
+                "lat": post.latitude,
+                "lon": post.longitude,
+            },
         )
         resp.raise_for_status()
     except requests.RequestException:

--- a/tests/test_search_index_server.py
+++ b/tests/test_search_index_server.py
@@ -24,9 +24,25 @@ def client():
         t2 = Tag(name='science')
         db.session.add_all([user, t1, t2])
         db.session.commit()
-        p1 = Post(title='Apple', body='apple banana', path='p1', language='en', author_id=user.id)
+        p1 = Post(
+            title='Apple',
+            body='apple banana',
+            path='p1',
+            language='en',
+            author_id=user.id,
+            latitude=10.0,
+            longitude=10.0,
+        )
         p1.tags.append(t1)
-        p2 = Post(title='Banana', body='banana carrot', path='p2', language='en', author_id=user.id)
+        p2 = Post(
+            title='Banana',
+            body='banana carrot',
+            path='p2',
+            language='en',
+            author_id=user.id,
+            latitude=20.0,
+            longitude=20.0,
+        )
         p2.tags.append(t2)
         db.session.add_all([p1, p2])
         db.session.commit()
@@ -105,3 +121,46 @@ def test_remote_metadata_search_success(client, monkeypatch):
     text_resp = resp.get_data(as_text=True)
     assert 'Banana' in text_resp
     assert captured == {'metadata.author': 'Alice'}
+
+
+def test_index_server_location_search(tmp_path):
+    db_path = 'search.db'
+    if hasattr(index_app, 'db') and getattr(index_app.db, 'conn', None):
+        index_app.db.conn.close()
+        del index_app.db.conn
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    with index_app.test_client() as c:
+        r = c.post('/index', json={'id': '1', 'title': 'One', 'body': 'foo', 'lat': 10, 'lon': 10})
+        assert r.status_code == 200
+        r = c.post('/index', json={'id': '2', 'title': 'Two', 'body': 'bar', 'lat': 20, 'lon': 20})
+        assert r.status_code == 200
+        rv = c.get('/search', query_string={'lat': 10, 'lon': 10, 'radius': 500})
+        assert rv.get_json() == ['1']
+
+
+def test_remote_location_search_success(client, monkeypatch):
+    with app.app_context():
+        apple = Post.query.filter_by(title='Apple').first()
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {'ids': [apple.id]}
+
+        def raise_for_status(self):
+            pass
+
+    captured = {}
+
+    def fake_get(url, params):
+        captured.update(params)
+        return FakeResponse()
+
+    monkeypatch.setenv('INDEX_SERVER_URL', 'http://index')
+    monkeypatch.setattr(requests, 'get', fake_get)
+    resp = client.get('/search', query_string={'lat': 10, 'lon': 10, 'radius': 500})
+    text_resp = resp.get_data(as_text=True)
+    assert 'Apple' in text_resp
+    assert captured == {'lat': 10.0, 'lon': 10.0, 'radius': 500.0}


### PR DESCRIPTION
## Summary
- extend index server schema with locations and R-tree tables
- support lat/lon index/search and integrate with app search
- document new geolocation API and add tests for R-tree search

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a28b3370ac8329bba8ac2c91bc5dfb