### PR TITLE
Prevent duplicate tags on posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1460,7 +1460,7 @@ def create_post():
             return redirect(url_for('create_post'))
         tag_names = [t.strip() for t in request.form['tags'].split(',') if t.strip()]
         tags = []
-        for name in tag_names:
+        for name in dict.fromkeys(tag_names):
             tag = Tag.query.filter_by(name=name).first()
             if not tag:
                 tag = Tag(name=name)
@@ -1619,7 +1619,7 @@ def api_create_post():
             t.strip() for t in tags_input if isinstance(t, str) and t.strip()
         ]
     tags = []
-    for name in tag_names:
+    for name in dict.fromkeys(tag_names):
         tag = Tag.query.filter_by(name=name).first()
         if not tag:
             tag = Tag(name=name)
@@ -2280,7 +2280,7 @@ def edit_post(post_id: int):
             )
         tag_names = [t.strip() for t in request.form['tags'].split(',') if t.strip()]
         post.tags = []
-        for name in tag_names:
+        for name in dict.fromkeys(tag_names):
             tag = Tag.query.filter_by(name=name).first()
             if not tag:
                 tag = Tag(name=name)

--- a/tests/test_duplicate_tags.py
+++ b/tests/test_duplicate_tags.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_duplicate_tags_are_deduplicated(client):
+    resp = client.post(
+        '/api/posts',
+        json={
+            'title': 'T',
+            'body': 'B',
+            'path': 'p1',
+            'tags': ['dupe', 'dupe', 'other'],
+        },
+    )
+    assert resp.status_code == 201
+    with app.app_context():
+        post = Post.query.filter_by(path='p1', language='en').first()
+        assert post is not None
+        assert sorted(t.name for t in post.tags) == ['dupe', 'other']
+        assert len(post.tags) == 2
+


### PR DESCRIPTION
## Summary
- avoid adding duplicate Tag objects when creating or editing posts
- cover duplicate tag behavior with regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a297b5e9e8832990ea113157e195a8