### PR TITLE
Fix saving suggested citation metadata

### DIFF
--- a/API.md
+++ b/API.md
@@ -307,7 +307,7 @@ Response
 {
   "results": {
     "Albert Einstein was born in Ulm.": [
-      {"text": "@misc{,\n  title={Einstein},\n  url={/en/einstein}\n}", "part": {"title": "Einstein", "url": "/en/einstein"}}
+      {"text": "@misc{1,\n  title={Einstein},\n  url={/en/einstein}\n}", "part": {"title": "Einstein", "url": "/en/einstein"}}
     ]
   }
 }
@@ -337,7 +337,7 @@ Response
 {
   "results": {
     "Quantum mechanics revolutionised physics.": [
-      {"text": "@misc{,\n  title={Quantum mechanics},\n  url={/en/quantum}\n}", "part": {"title": "Quantum mechanics", "url": "/en/quantum"}}
+      {"text": "@misc{2,\n  title={Quantum mechanics},\n  url={/en/quantum}\n}", "part": {"title": "Quantum mechanics", "url": "/en/quantum"}}
     ]
   }
 }

--- a/app.py
+++ b/app.py
@@ -256,7 +256,8 @@ def suggest_citations(markdown_text: str) -> dict[str, list[dict]]:
         for post in posts:
             url = f"/{post.language}/{post.path}"
             entry = {'title': post.title, 'url': url}
-            bibtex = f"@misc{{,\n  title={{ {post.title} }},\n  url={{ {url} }}\n}}"
+            key = post.id
+            bibtex = f"@misc{{{key},\n  title={{ {post.title} }},\n  url={{ {url} }}\n}}"
             candidates.append({'text': bibtex, 'part': entry})
         if candidates:
             results[sentence] = candidates

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -223,7 +223,6 @@
 {% if current_user.is_authenticated %}
 <section class="d-print-none">
   <h2>{{ _('Suggest Citation') }}</h2>
-  <p>{{ _('Use the buttons next to each paragraph to get suggestions.') }}</p>
 </section>
 <section class="d-print-none">
   <h2>{{ _('Add Citation') }}</h2>

--- a/tests/test_suggest_citation_save.py
+++ b/tests/test_suggest_citation_save.py
@@ -1,0 +1,53 @@
+import os
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_save_suggested_citation(client):
+    # Create a post that will receive the citation
+    resp = client.post(
+        '/post/new',
+        data={
+            'title': 'Main',
+            'body': 'Body',
+            'path': 'main',
+            'language': 'en',
+            'tags': '',
+            'metadata': '',
+            'user_metadata': '',
+        },
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        post_id = Post.query.filter_by(path='main').first().id
+        bibtex = "@misc{123,\n  title={Reference},\n  url={/en/ref}\n}"
+    resp = client.post(
+        f'/post/{post_id}/citation/new',
+        data={'citation_text': bibtex},
+    )
+    assert resp.status_code == 302
+    with app.app_context():
+        cit = PostCitation.query.filter_by(post_id=post_id).first()
+        assert cit.citation_part['title'] == 'Reference'
+        assert cit.citation_part['url'] == '/en/ref'


### PR DESCRIPTION
## Summary
- Remove unused instruction text above Suggest Citation form
- Ensure suggested citations include a BibTeX key so saved entries retain metadata
- Document new BibTeX format in API guide
- Add regression test for saving suggested citations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a29ab3a7e88329ae68356ef5214545