### PR TITLE
Add BibTeX meta tags for post pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1738,6 +1738,13 @@ def post_detail(post_id: int):
         )
     base = url_for('document', language=post.language, doc_path='')
     html_body, toc = render_markdown(post.body, base, with_toc=True)
+    canonical_url = url_for('document', language=post.language, doc_path=post.path, _external=True)
+    year = created_at.year if created_at else datetime.utcnow().year
+    key = re.sub(r'\W+', '', f"{post.author.username}{year}{post.id}")
+    bibtex = (
+        f"@misc{{{key}, title={{ {post.title} }}, author={{ {post.author.username} }}, "
+        f"year={{ {year} }}, url={{ {canonical_url} }} }}"
+    )
     return render_template(
         'post_detail.html',
         post=post,
@@ -1754,6 +1761,8 @@ def post_detail(post_id: int):
         views=views,
         created_at=created_at,
         address=address,
+        bibtex=bibtex,
+        canonical_url=canonical_url,
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}" media="print">
+  {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
 </head>
 <body>

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 {% block title %}{{ post.display_title }}{% endblock %}
+{% block extra_head %}
+<meta name="citation_title" content="{{ post.title }}">
+<meta name="citation_author" content="{{ post.author.username }}">
+{% if created_at %}<meta name="citation_publication_date" content="{{ created_at.strftime('%Y/%m/%d') }}">{% endif %}
+<meta name="citation_language" content="{{ post.language }}">
+<meta name="citation_fulltext_html_url" content="{{ canonical_url }}">
+<meta name="citation_bibtex" content="{{ bibtex|e }}">
+{% endblock %}
 {% block content %}
 <nav id="reading-breadcrumb" aria-label="breadcrumb" class="mb-2" style="display:none;">
   <ol class="breadcrumb mb-0"></ol>

--- a/tests/test_bibtex_meta.py
+++ b/tests/test_bibtex_meta.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, Revision
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def _create_post():
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        post = Post(title='Title', body='Body', path='p', language='en', author=user)
+        db.session.add(post)
+        db.session.commit()
+        rev = Revision(
+            post_id=post.id,
+            user_id=user.id,
+            title=post.title,
+            body=post.body,
+            path=post.path,
+            language=post.language,
+        )
+        db.session.add(rev)
+        db.session.commit()
+        return post.id
+
+
+def test_bibtex_meta_tags_present(client):
+    post_id = _create_post()
+    resp = client.get(f'/post/{post_id}')
+    assert resp.status_code == 200
+    html = resp.data.decode('utf-8')
+    assert '<meta name="citation_title" content="Title">' in html
+    assert '<meta name="citation_author" content="author">' in html
+    assert 'citation_bibtex' in html
+


### PR DESCRIPTION
## Summary
- allow templates to inject extra head tags
- generate BibTeX meta tags for posts to support citations
- test BibTeX meta tag rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a29ad36fd883298e00595c15cde901