### PR TITLE
Handle tag queries by translated labels case-insensitively

### DIFF
--- a/tests/test_post_categories.py
+++ b/tests/test_post_categories.py
@@ -50,6 +50,30 @@ def test_posts_category_filter(client):
     assert b'Tech Post' not in resp.data
     assert b'Misc Post' not in resp.data
 
+    # Case-insensitive tag lookup
+    resp = client.get('/posts', query_string={'tag': 'News'})
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+
+    # Lookup by translated label
+    resp = client.get('/posts', query_string={'tag': 'noticias'})
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+
+    # Lookup by translated label with different casing
+    resp = client.get('/posts', query_string={'tag': 'Noticias'})
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+
+    # Tag page should also resolve translated names
+    resp = client.get('/tag/noticias')
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+
+    resp = client.get('/tag/Noticias')
+    assert b'News Post' in resp.data
+    assert b'Tech Post' not in resp.data
+
     with app.app_context():
         assert ('news', 'noticias') in get_category_tags('es')
 


### PR DESCRIPTION
## Summary
- Allow `/posts` and `/tag/<name>` to resolve tag names case-insensitively
- Resolve tag parameters using category translations from settings
- Test tag filtering and tag pages with translated and mixed-case names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a29c3f50b48329b0cde685b6ba30e8