### PR TITLE
Remove redundant Suggest Citation header

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -230,9 +230,6 @@
 {% endif %}
 {% if current_user.is_authenticated %}
 <section class="d-print-none">
-  <h2>{{ _('Suggest Citation') }}</h2>
-</section>
-<section class="d-print-none">
   <h2>{{ _('Add Citation') }}</h2>
   <form id="citation-form" action="{{ url_for('new_citation', post_id=post.id) }}" method="post">
     <div class="mb-2 d-flex gap-1">


### PR DESCRIPTION
## Summary
- simplify post detail layout by removing the unused "Suggest Citation" heading
- keep per-paragraph suggestion button and add citation form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a29cb212688329b7771e26c9318d4b