### PR TITLE
Fix markdown preview escaping

### DIFF
--- a/app.py
+++ b/app.py
@@ -1988,8 +1988,7 @@ def markdown_preview():
     text = data.get('text', '')
     language = data.get('language', 'en')
     base = url_for('document', language=language, doc_path='')
-    escaped = escape(text)
-    html, _ = render_markdown(str(escaped), base)
+    html, _ = render_markdown(text, base)
     return {'html': str(Markup(html))}
 
 

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -57,3 +57,8 @@ def client():
 def test_markdown_preview_language(client):
     resp = client.post('/markdown/preview', json={'text': '[[Page]]', 'language': 'es'})
     assert resp.get_json()['html'] == '<p><a href="/es/Page">Page</a></p>'
+
+
+def test_markdown_preview_renders_html(client):
+    resp = client.post('/markdown/preview', json={'text': '<b>bold</b>'})
+    assert resp.get_json()['html'] == '<p><b>bold</b></p>'


### PR DESCRIPTION
## Summary
- ensure markdown preview renders raw text without HTML escaping
- add regression test for HTML rendering in preview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a29f145af88329a6c11dcfac4f328c