### PR TITLE
Fix markdown preview not rendering in editor

### DIFF
--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -159,9 +159,6 @@ document.querySelectorAll('input[name="language"]').forEach(el => {
 updatePreview();
 
 const map = L.map('map').setView([0, 0], 2);
-
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-
 const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
 const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const isDark = () => document.body.classList.contains('dark-mode') || localStorage.getItem('theme') !== 'light';


### PR DESCRIPTION
## Summary
- remove stray L.tileLayer call in post form script that broke JavaScript
- allow markdown preview to render alongside editor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2a181b1c48329998e955f51085127