### PR TITLE
Allow styling site title via settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -2575,6 +2575,7 @@ def settings():
     if not current_user.is_admin():
         abort(403)
     title = get_setting('site_title', '')
+    title_style = get_setting('site_title_style', '')
     home_page = get_setting('home_page_path', '')
     timezone_value = get_setting('timezone', 'UTC')
     rss_enabled_val = get_setting('rss_enabled', 'false')
@@ -2585,6 +2586,7 @@ def settings():
     if request.method == 'POST':
 
         title = request.form.get('site_title', title).strip()
+        title_style = request.form.get('site_title_style', title_style).strip()
         home_page = request.form.get('home_page_path', home_page).strip()
         tz_input = request.form.get('timezone', timezone_value).strip() or 'UTC'
         tz_norm = normalize_timezone(tz_input)
@@ -2612,6 +2614,12 @@ def settings():
         else:
             title_setting = Setting(key='site_title', value=title)
             db.session.add(title_setting)
+
+        style_setting = Setting.query.filter_by(key='site_title_style').first()
+        if style_setting:
+            style_setting.value = title_style
+        else:
+            db.session.add(Setting(key='site_title_style', value=title_style))
 
         if 'home_page_path' in request.form:
             home_page = request.form['home_page_path'].strip()
@@ -2662,6 +2670,7 @@ def settings():
     return render_template(
         'settings.html',
         site_title=title,
+        site_title_style=title_style,
         home_page_path=home_page,
         timezone=timezone_value,
         rss_enabled=rss_enabled_val.lower() in ['true', '1', 'yes', 'on'],

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,8 @@
 <body>
 <nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">{{ get_setting('site_title', _('Spacetime')) }}</a>
+    {% set site_title_style = get_setting('site_title_style', '') %}
+    <a class="navbar-brand" href="{{ url_for('index') }}"{% if site_title_style %} style="{{ site_title_style }}"{% endif %}>{{ get_setting('site_title', _('Spacetime')) }}</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,6 +8,11 @@
       <input type="text" id="site_title" name="site_title" class="form-control" value="{{ site_title }}">
     </div>
     <div class="mb-3">
+      <label for="site_title_style" class="form-label">{{ _('Site title CSS') }}</label>
+      <input type="text" id="site_title_style" name="site_title_style" class="form-control" value="{{ site_title_style }}">
+      <div class="form-text">{{ _('Inline CSS for site title in navigation bar') }}</div>
+    </div>
+    <div class="mb-3">
       <label for="home_page_path" class="form-label">{{ _('Home page path') }}</label>
       <input type="text" id="home_page_path" name="home_page_path" class="form-control" value="{{ home_page_path }}">
     </div>


### PR DESCRIPTION
## Summary
- add `site_title_style` setting editable in admin settings
- apply custom inline CSS to navbar site title

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a2a2feb614832990722a8dae2ec1ea