### PR TITLE
Ensure citation URLs include domain

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import markdown
 import math
 from datetime import datetime, timezone
 from xml.etree.ElementTree import Element, SubElement, tostring
-from urllib.parse import urlparse, quote
+from urllib.parse import urlparse, quote, urljoin
 
 from flask import (
     Flask,
@@ -518,13 +518,21 @@ def format_citation_mla(part: dict, doi: str | None = None) -> Markup:
     if pages:
         pieces.append(f"pp. {escape(str(pages).rstrip('.'))}")
     if not pieces and part.get('url'):
-        url = escape(str(part['url']))
+        raw_url = str(part['url'])
+        parsed = urlparse(raw_url)
+        if not parsed.scheme:
+            raw_url = urljoin(request.url_root, raw_url)
+        url = escape(raw_url)
         return Markup(f'<a href="{url}">{url}</a>')
     citation = '. '.join(pieces)
     if doi:
         citation += f". <a href=\"https://doi.org/{doi}\">https://doi.org/{doi}</a>"
     elif part.get('url'):
-        url = escape(str(part['url']))
+        raw_url = str(part['url'])
+        parsed = urlparse(raw_url)
+        if not parsed.scheme:
+            raw_url = urljoin(request.url_root, raw_url)
+        url = escape(raw_url)
         citation += f". <a href=\"{url}\">{url}</a>"
     return Markup(citation)
 

--- a/tests/test_citation_format.py
+++ b/tests/test_citation_format.py
@@ -1,4 +1,4 @@
-from app import format_citation_mla, normalize_doi
+from app import format_citation_mla, normalize_doi, app as flask_app
 
 def test_normalize_doi():
     assert normalize_doi('https://doi.org/10.1000/XYZ') == '10.1000/xyz'
@@ -27,3 +27,10 @@ def test_format_citation_mla_url_only():
     part = {'url': 'https://example.com'}
     result = format_citation_mla(part, None)
     assert str(result) == '<a href="https://example.com">https://example.com</a>'
+
+
+def test_format_citation_mla_relative_url():
+    part = {'url': '/foo'}
+    with flask_app.test_request_context('/'):
+        result = format_citation_mla(part, None)
+    assert str(result) == '<a href="http://localhost/foo">http://localhost/foo</a>'


### PR DESCRIPTION
## Summary
- convert relative citation URLs to absolute links with current domain
- test MLA citation formatting for relative URLs

## Testing
- `PYTHONPATH=. pytest tests/test_citation_format.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2dc634ab483299f6afbc7ce2ba9e1