### PR TITLE
Refactor app into modular structure

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,189 @@
+"""API blueprint for spacetime.
+
+Routes that expose JSON endpoints are collected here to keep ``app.py``
+focused on application setup and HTML views.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request, current_app, url_for
+from flask_login import current_user, login_required
+from flask_babel import _
+from langdetect import detect, LangDetectException
+
+from models import (
+    db,
+    Post,
+    Tag,
+    PostMetadata,
+    Revision,
+    PostCitation,
+    UserPostCitation,
+    PostWatch,
+    Notification,
+)
+
+
+api_bp = Blueprint("api", __name__, url_prefix="/api")
+
+
+@api_bp.route("/posts", methods=["POST"])
+@login_required
+def create_post():
+    """Create a new post via the API."""
+    from app import geocode_address, generate_unique_path, update_post_links
+
+    if not current_user.can_edit_posts():
+        return jsonify({"error": "forbidden"}), 403
+    if not request.is_json:
+        return jsonify({"error": "invalid JSON"}), 400
+    data = request.get_json() or {}
+    title = (data.get("title") or "").strip()
+    body = (data.get("body") or "").strip()
+    path = (data.get("path") or "").strip()
+    language = (data.get("language") or "").strip()
+    address = (data.get("address") or "").strip()
+    lat_val = data.get("lat")
+    lon_val = data.get("lon")
+    lat = lon = None
+    if address and lat_val is None and lon_val is None:
+        coords = geocode_address(address)
+        if not coords:
+            return jsonify({"error": "invalid address"}), 400
+        lat_val, lon_val = coords
+    if lat_val is not None and lon_val is not None:
+        try:
+            lat = float(lat_val)
+            lon = float(lon_val)
+        except (TypeError, ValueError):
+            return jsonify({"error": "invalid coordinates"}), 400
+    elif lat_val is not None or lon_val is not None:
+        return jsonify({"error": "lat and lon required"}), 400
+    if not title or not body:
+        return jsonify({"error": "title and body required"}), 400
+    if language not in current_app.config["LANGUAGES"]:
+        try:
+            language = detect(body)
+        except LangDetectException:
+            language = current_app.config["BABEL_DEFAULT_LOCALE"]
+        if language not in current_app.config["LANGUAGES"]:
+            language = current_app.config["BABEL_DEFAULT_LOCALE"]
+    if not path or Post.query.filter_by(path=path, language=language).first():
+        path = generate_unique_path(title, language)
+    tags_input = data.get("tags", [])
+    if isinstance(tags_input, str):
+        tag_names = [t.strip() for t in tags_input.split(",") if t.strip()]
+    else:
+        tag_names = [
+            t.strip() for t in tags_input if isinstance(t, str) and t.strip()
+        ]
+    tags = []
+    for name in dict.fromkeys(tag_names):
+        tag = Tag.query.filter_by(name=name).first()
+        if not tag:
+            tag = Tag(name=name)
+            db.session.add(tag)
+        tags.append(tag)
+    post = Post(
+        title=title,
+        body=body,
+        path=path,
+        language=language,
+        author=current_user,
+        tags=tags,
+    )
+    db.session.add(post)
+    if lat is not None and lon is not None:
+        post.latitude = lat
+        post.longitude = lon
+        db.session.add(PostMetadata(post=post, key="lat", value=str(lat)))
+        db.session.add(PostMetadata(post=post, key="lon", value=str(lon)))
+    db.session.flush()
+    update_post_links(post)
+    comment = (data.get("comment") or "").strip()
+    rev = Revision(
+        post=post,
+        user=current_user,
+        title=title,
+        body=body,
+        path=path,
+        language=language,
+        comment=comment,
+        byte_change=len(body),
+    )
+    db.session.add(rev)
+    db.session.commit()
+    return (
+        jsonify(
+            {
+                "id": post.id,
+                "path": post.path,
+                "language": post.language,
+                "title": post.title,
+            }
+        ),
+        201,
+    )
+
+
+@api_bp.route("/posts/<int:post_id>/citation", methods=["POST"])
+@login_required
+def add_url_citation(post_id: int):
+    from app import is_url
+
+    post = Post.query.get_or_404(post_id)
+    if not request.is_json:
+        return jsonify({"error": "invalid JSON"}), 400
+    data = request.get_json() or {}
+    url = (data.get("url") or "").strip()
+    context = (data.get("context") or "").strip()
+    if not url or not is_url(url):
+        return jsonify({"error": "valid URL required"}), 400
+    existing = PostCitation.query.filter_by(
+        post_id=post.id, citation_text=url
+    ).first()
+    if not existing:
+        existing = UserPostCitation.query.filter_by(
+            post_id=post.id, citation_text=url
+        ).first()
+    if existing:
+        return jsonify({"error": "Citation with this URL already exists."}), 400
+    entry = {"url": url}
+    if current_user.id == post.author_id or current_user.is_admin():
+        citation = PostCitation(
+            post=post,
+            user=current_user,
+            citation_part=entry,
+            citation_text=url,
+            context=context,
+            doi=None,
+            bibtex_raw=url,
+            bibtex_fields=entry,
+        )
+    else:
+        citation = UserPostCitation(
+            post=post,
+            user=current_user,
+            citation_part=entry,
+            citation_text=url,
+            context=context,
+            doi=None,
+            bibtex_raw=url,
+            bibtex_fields=entry,
+        )
+    db.session.add(citation)
+    watcher_ids = {
+        w.user_id for w in PostWatch.query.filter_by(post_id=post.id).all()
+    }
+    watcher_ids.add(post.author_id)
+    link = url_for("post_detail", post_id=post.id)
+    for uid in watcher_ids:
+        if uid != current_user.id:
+            msg = _("Citation added to \"%(title)s\".", title=post.title)
+            db.session.add(Notification(user_id=uid, message=msg, link=link))
+    db.session.commit()
+    return jsonify({"id": citation.id, "url": url}), 201
+
+
+__all__ = ["api_bp"]
+

--- a/models.py
+++ b/models.py
@@ -1,0 +1,321 @@
+"""Database models for the spacetime application.
+
+This module defines the SQLAlchemy ``db`` instance and all ORM models
+previously kept in ``app.py``.  Separating them into their own module keeps
+``app.py`` focused on application wiring while models remain importable
+from a single place.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from flask_babel import _
+from flask_login import UserMixin
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import event, text
+from werkzeug.security import check_password_hash, generate_password_hash
+
+
+db = SQLAlchemy()
+
+
+# Roles allowed to create or edit posts
+POST_EDITOR_ROLES = {"editor", "admin"}
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default="user")
+    bio = db.Column(db.Text)
+    locale = db.Column(db.String(8))
+    timezone = db.Column(db.String(50), default="UTC")
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    def is_admin(self) -> bool:
+        return self.role == "admin"
+
+    def can_edit_posts(self) -> bool:
+        return self.role in POST_EDITOR_ROLES
+
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    path = db.Column(db.String(200), nullable=False)
+    language = db.Column(db.String(8), nullable=False, default="en")
+    author_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    author = db.relationship("User", backref="posts")
+    tags = db.relationship("Tag", secondary="post_tag", backref="posts")
+    latitude = db.Column(db.Float)
+    longitude = db.Column(db.Float)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    __table_args__ = (
+        db.UniqueConstraint("path", "language", name="uix_path_language"),
+    )
+
+    @property
+    def display_title(self) -> str:
+        """Return title or a placeholder if the post was deleted."""
+        return self.title or _("[deleted]")
+
+
+@event.listens_for(Post.__table__, "after_create")
+def create_post_fts(target, connection, **kw):
+    """Create FTS5 table and triggers for Post.body."""
+    connection.execute(
+        text(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS post_fts "
+            "USING fts5(body, content=\"post\", content_rowid=\"id\")"
+        )
+    )
+    connection.execute(
+        text(
+            "CREATE TRIGGER post_fts_ai AFTER INSERT ON post BEGIN "
+            "INSERT INTO post_fts(rowid, body) VALUES (new.id, new.body); "
+            "END;"
+        )
+    )
+    connection.execute(
+        text(
+            "CREATE TRIGGER post_fts_ad AFTER DELETE ON post BEGIN "
+            "INSERT INTO post_fts(post_fts, rowid, body) VALUES('delete', old.id, old.body); "
+            "END;"
+        )
+    )
+    connection.execute(
+        text(
+            "CREATE TRIGGER post_fts_au AFTER UPDATE ON post BEGIN "
+            "INSERT INTO post_fts(post_fts, rowid, body) VALUES('delete', old.id, old.body); "
+            "INSERT INTO post_fts(rowid, body) VALUES (new.id, new.body); "
+            "END;"
+        )
+    )
+
+
+class Tag(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+
+
+class PostTag(db.Model):
+    __tablename__ = "post_tag"
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), primary_key=True)
+    tag_id = db.Column(db.Integer, db.ForeignKey("tag.id"), primary_key=True)
+
+
+class PostLink(db.Model):
+    __tablename__ = "post_link"
+    source_id = db.Column(db.Integer, db.ForeignKey("post.id"), primary_key=True)
+    target_id = db.Column(db.Integer, db.ForeignKey("post.id"), primary_key=True)
+
+    source = db.relationship(
+        "Post", foreign_keys=[source_id], backref="outgoing_links"
+    )
+    target = db.relationship(
+        "Post", foreign_keys=[target_id], backref="incoming_links"
+    )
+
+
+class PostWatch(db.Model):
+    __tablename__ = "post_watch"
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
+
+    post = db.relationship(
+        "Post", backref=db.backref("watchers", cascade="all, delete-orphan")
+    )
+    user = db.relationship("User", backref="watched_posts")
+
+
+class PostMetadata(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    key = db.Column(db.String(50), nullable=False)
+    value = db.Column(db.JSON, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint("post_id", "key", name="uix_post_metadata_key"),
+    )
+
+    post = db.relationship(
+        "Post", backref=db.backref("metadata", cascade="all, delete-orphan")
+    )
+
+
+class UserPostMetadata(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    key = db.Column(db.String(50), nullable=False)
+    value = db.Column(db.JSON, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "post_id", "user_id", "key", name="uix_post_user_metadata_key"
+        ),
+    )
+
+    post = db.relationship("Post", backref="user_metadata")
+    user = db.relationship("User")
+
+
+class Notification(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    message = db.Column(db.String(200), nullable=False)
+    link = db.Column(db.String(200), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    read_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship("User", backref="notifications")
+
+
+class RequestedPost(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    requester_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    admin_comment = db.Column(db.String(200), default="")
+
+    requester = db.relationship("User", backref="requested_posts")
+
+
+class Redirect(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    old_path = db.Column(db.String(200), nullable=False)
+    new_path = db.Column(db.String(200), nullable=False)
+    language = db.Column(db.String(8), nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "old_path", "language", name="uix_redirect_oldpath_language"
+        ),
+    )
+
+
+class Setting(db.Model):
+    key = db.Column(db.String(50), primary_key=True)
+    value = db.Column(db.Text, nullable=True)
+
+
+class PostCitation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    citation_part = db.Column(db.JSON, nullable=False)
+    citation_text = db.Column(db.Text, nullable=False)
+    context = db.Column(db.Text)
+    doi = db.Column(db.String, nullable=True)
+    bibtex_raw = db.Column(db.Text, nullable=False)
+    bibtex_fields = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    post = db.relationship(
+        "Post", backref=db.backref("citations", cascade="all, delete-orphan")
+    )
+    user = db.relationship("User")
+
+
+class UserPostCitation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    citation_part = db.Column(db.JSON, nullable=False)
+    citation_text = db.Column(db.Text, nullable=False)
+    context = db.Column(db.Text)
+    doi = db.Column(db.String, nullable=True)
+    bibtex_raw = db.Column(db.Text, nullable=False)
+    bibtex_fields = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    post = db.relationship("Post", backref="user_citations")
+    user = db.relationship("User")
+
+
+db.Index("ix_post_metadata_key_post", PostMetadata.key, PostMetadata.post_id)
+db.Index(
+    "ix_user_post_metadata_key_post_user",
+    UserPostMetadata.key,
+    UserPostMetadata.post_id,
+    UserPostMetadata.user_id,
+)
+db.Index("ix_post_citation_post_id", PostCitation.post_id)
+db.Index("ix_post_citation_user_id", PostCitation.user_id)
+db.Index("ix_user_post_citation_post_id", UserPostCitation.post_id)
+db.Index("ix_user_post_citation_user_id", UserPostCitation.user_id)
+db.Index(
+    "uq_post_citation_doi",
+    PostCitation.post_id,
+    PostCitation.doi,
+    unique=True,
+    sqlite_where=db.text("doi IS NOT NULL"),
+)
+db.Index(
+    "uq_post_citation_text",
+    PostCitation.post_id,
+    PostCitation.citation_text,
+    unique=True,
+    sqlite_where=db.text("doi IS NULL"),
+)
+db.Index(
+    "uq_user_post_citation_doi",
+    UserPostCitation.post_id,
+    UserPostCitation.doi,
+    unique=True,
+    sqlite_where=db.text("doi IS NOT NULL"),
+)
+db.Index(
+    "uq_user_post_citation_text",
+    UserPostCitation.post_id,
+    UserPostCitation.citation_text,
+    unique=True,
+    sqlite_where=db.text("doi IS NULL"),
+)
+
+
+class Revision(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey("post.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    path = db.Column(db.String(200), nullable=False)
+    language = db.Column(db.String(8), nullable=False, default="en")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    comment = db.Column(db.String(200), default="")
+    byte_change = db.Column(db.Integer, default=0)
+
+    user = db.relationship("User")
+    post = db.relationship("Post", backref="revisions")
+
+
+__all__ = [
+    "db",
+    "POST_EDITOR_ROLES",
+    "User",
+    "Post",
+    "Tag",
+    "PostTag",
+    "PostLink",
+    "PostWatch",
+    "PostMetadata",
+    "UserPostMetadata",
+    "Notification",
+    "RequestedPost",
+    "Redirect",
+    "Setting",
+    "PostCitation",
+    "UserPostCitation",
+    "Revision",
+]
+


### PR DESCRIPTION
## Summary
- Move SQLAlchemy models from app.py into standalone models module
- Extract JSON routes into an API blueprint and register with the app
- Simplify app initialization by importing models and initializing DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2ddbc4e6083299381448db03093cd