### PR TITLE
Expand wiki API for search and post management

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,7 +33,10 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/post/<int:post_id>/watch` | `POST` | Watch a post for changes |
 | `/post/<string:language>/<path:doc_path>` | `GET` | View a post by language and path |
 | `/post/new` | `GET, POST` | Create a new post |
+| `/api/posts` | `GET` | Search posts with optional pagination |
 | `/api/posts` | `POST` | Create a new post via JSON (supports location) |
+| `/api/posts/<int:post_id>` | `GET` | Read post content and metadata |
+| `/api/posts/<int:post_id>` | `PUT` | Update post content and metadata |
 | `/post/request` | `GET, POST` | Request that a post be created |
 | `/posts` | `GET` | List all posts |
 | `/posts/requested` | `GET` | List user requested posts |
@@ -96,10 +99,28 @@ Create a new post. POST fields include `title`, `body`, `path`, `language`, `com
 `tags` (comma-separated), optional `metadata` and `user_metadata` JSON strings, and
 optional `lat`/`lon` coordinates.
 
+### `/api/posts` (`GET`)
+Search posts and return matching entries in JSON. Supports query parameters:
+
+- `q` – full-text search string (optional)
+- `limit` – number of results to return (0 for all, default 20)
+- `offset` – starting index of results (default 0)
+
+Returns an object with `total` result count and a `posts` array containing each
+post's `id`, `path`, `language`, and `title`.
+
 ### `/api/posts` (`POST`)
 Create a new post using a JSON body. Accepts `title` and `body` fields, with optional
 `path`, `language`, `address`, `lat`/`lon`, and `tags` (comma-separated string or list).
 Returns basic information about the created post.
+
+### `/api/posts/<int:post_id>` (`GET`)
+Return the specified post's `title`, `body`, and associated metadata.
+
+### `/api/posts/<int:post_id>` (`PUT`)
+Update an existing post. Requires authentication and accepts `title`, `body`, optional
+`path`, `language`, and a `metadata` object for key/value pairs such as `lat`/`lon`.
+Returns basic information about the updated post.
 
 ### `/post/<int:post_id>` (`GET`)
 View an individual post by ID.
@@ -244,6 +265,63 @@ Response
 
 ```json
 {"id": 1, "path": "api-path", "language": "en", "title": "API Title"}
+```
+
+### `/api/posts` (`GET`)
+
+Search for posts and return paginated results.
+
+**Example**
+
+Request
+
+```http
+GET /api/posts?q=apple&limit=2&offset=1
+```
+
+Response
+
+```json
+{"total": 3, "posts": [{"id": 2, "path": "p1", "language": "en", "title": "Apple 1"}, {"id": 1, "path": "p0", "language": "en", "title": "Apple 0"}]}
+```
+
+### `/api/posts/<int:post_id>` (`GET`)
+
+Retrieve the full content and metadata for a post.
+
+**Example**
+
+Request
+
+```http
+GET /api/posts/1
+```
+
+Response
+
+```json
+{"id": 1, "path": "p0", "language": "en", "title": "Apple 0", "body": "apple", "metadata": {"foo": "bar"}}
+```
+
+### `/api/posts/<int:post_id>` (`PUT`)
+
+Update an existing post's content or metadata.
+
+**Example**
+
+Request
+
+```http
+PUT /api/posts/1
+Content-Type: application/json
+
+{"title": "New", "body": "Updated", "metadata": {"foo": "baz"}}
+```
+
+Response
+
+```json
+{"id": 1, "path": "p0", "language": "en", "title": "New"}
 ```
 
 ### `/og` (`GET`)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -27,6 +27,42 @@ from models import (
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
 
+@api_bp.route("/posts", methods=["GET"])
+def search_posts():
+    """Search posts with optional full-text query and pagination."""
+    from sqlalchemy import text
+
+    q = (request.args.get("q") or "").strip()
+    limit = request.args.get("limit", type=int)
+    offset = request.args.get("offset", type=int, default=0)
+
+    query = Post.query
+    if q:
+        ids = [
+            row[0]
+            for row in db.session.execute(
+                text("SELECT rowid FROM post_fts WHERE post_fts MATCH :q"),
+                {"q": q},
+            )
+        ]
+        query = query.filter(Post.id.in_(ids)) if ids else query.filter(False)
+
+    total = query.count()
+    query = query.order_by(Post.id.desc())
+    if offset:
+        query = query.offset(offset)
+    if limit and limit > 0:
+        posts = query.limit(limit).all()
+    else:
+        posts = query.all()
+
+    data = [
+        {"id": p.id, "path": p.path, "language": p.language, "title": p.title}
+        for p in posts
+    ]
+    return jsonify({"posts": data, "total": total})
+
+
 @api_bp.route("/posts", methods=["POST"])
 @login_required
 def create_post():
@@ -123,6 +159,106 @@ def create_post():
             }
         ),
         201,
+    )
+
+
+@api_bp.route("/posts/<int:post_id>", methods=["GET"])
+def get_post(post_id: int):
+    """Return a post's content and metadata."""
+    post = Post.query.get_or_404(post_id)
+    metadata = {m.key: m.value for m in post.metadata}
+    return jsonify(
+        {
+            "id": post.id,
+            "path": post.path,
+            "language": post.language,
+            "title": post.title,
+            "body": post.body,
+            "metadata": metadata,
+        }
+    )
+
+
+@api_bp.route("/posts/<int:post_id>", methods=["PUT"])
+@login_required
+def update_post(post_id: int):
+    """Update a post's content and metadata."""
+    from app import generate_unique_path, update_post_links
+
+    post = Post.query.get_or_404(post_id)
+    if not current_user.can_edit_posts():
+        return jsonify({"error": "forbidden"}), 403
+    if not request.is_json:
+        return jsonify({"error": "invalid JSON"}), 400
+    data = request.get_json() or {}
+
+    title = (data.get("title") or post.title).strip()
+    body = (data.get("body") or post.body)
+    path = (data.get("path") or post.path).strip()
+    language = (data.get("language") or post.language).strip()
+    comment = (data.get("comment") or "").strip()
+
+    if not title or not body:
+        return jsonify({"error": "title and body required"}), 400
+
+    existing = (
+        Post.query.filter_by(path=path, language=language)
+        .filter(Post.id != post.id)
+        .first()
+    )
+    if existing:
+        return jsonify({"error": "path already exists"}), 400
+
+    old_body = post.body
+    rev = Revision(
+        post=post,
+        user=current_user,
+        title=post.title,
+        body=old_body,
+        path=post.path,
+        language=post.language,
+        comment=comment,
+    )
+    db.session.add(rev)
+
+    post.title = title
+    post.body = body
+    post.path = path or generate_unique_path(title, language)
+    post.language = language
+
+    meta = data.get("metadata")
+    if isinstance(meta, dict):
+        current_views = PostMetadata.query.filter_by(post_id=post.id, key="views").first()
+        PostMetadata.query.filter(
+            PostMetadata.post_id == post.id, PostMetadata.key != "views"
+        ).delete(synchronize_session=False)
+        for key, value in meta.items():
+            if key in {"lat", "lon"}:
+                value = str(value)
+            db.session.add(PostMetadata(post=post, key=key, value=value))
+        if current_views:
+            db.session.add(current_views)
+        lat_val = meta.get("lat")
+        lon_val = meta.get("lon")
+        if lat_val is not None and lon_val is not None:
+            try:
+                post.latitude = float(lat_val)
+                post.longitude = float(lon_val)
+            except (TypeError, ValueError):
+                post.latitude = post.longitude = None
+        else:
+            post.latitude = post.longitude = None
+
+    update_post_links(post)
+    rev.byte_change = len(post.body) - len(old_body)
+    db.session.commit()
+    return jsonify(
+        {
+            "id": post.id,
+            "path": post.path,
+            "language": post.language,
+            "title": post.title,
+        }
     )
 
 

--- a/tests/test_api_read_update_post.py
+++ b/tests/test_api_read_update_post.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostMetadata
+
+
+@pytest.fixture
+def client_and_post():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        post = Post(title='Old Title', body='Old Body', path='old', language='en', author_id=user.id)
+        db.session.add(post)
+        db.session.add(PostMetadata(post=post, key='foo', value='bar'))
+        db.session.commit()
+        pid = post.id
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client, pid
+    with app.app_context():
+        db.drop_all()
+
+
+def test_api_get_post(client_and_post):
+    client, pid = client_and_post
+    resp = client.get(f'/api/posts/{pid}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['title'] == 'Old Title'
+    assert data['metadata']['foo'] == 'bar'
+
+
+def test_api_update_post(client_and_post):
+    client, pid = client_and_post
+    resp = client.put(
+        f'/api/posts/{pid}',
+        json={'title': 'New Title', 'body': 'New Body', 'metadata': {'foo': 'baz', 'lat': 1.0, 'lon': 2.0}},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['title'] == 'New Title'
+    with app.app_context():
+        post = Post.query.get(pid)
+        assert post.title == 'New Title'
+        assert post.body == 'New Body'
+        meta = {m.key: m.value for m in post.metadata}
+        assert meta['foo'] == 'baz'
+        assert meta['lat'] == '1.0'
+        assert meta['lon'] == '2.0'
+        assert post.latitude == 1.0
+        assert post.longitude == 2.0

--- a/tests/test_api_search_posts.py
+++ b/tests/test_api_search_posts.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+from sqlalchemy import text
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.drop_all()
+        db.session.execute(text('DROP TABLE IF EXISTS post_fts'))
+        db.create_all()
+        user = User(username='u')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        posts = [
+            Post(title=f'Apple {i}', body='apple', path=f'p{i}', language='en', author_id=user.id)
+            for i in range(3)
+        ]
+        db.session.add_all(posts)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+        db.session.execute(text('DROP TABLE IF EXISTS post_fts'))
+
+
+def test_api_search_pagination(client):
+    resp = client.get('/api/posts', query_string={'q': 'apple', 'limit': 2})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['total'] == 3
+    titles = [p['title'] for p in data['posts']]
+    assert titles == ['Apple 2', 'Apple 1']
+
+    resp = client.get('/api/posts', query_string={'q': 'apple', 'limit': 2, 'offset': 2})
+    data = resp.get_json()
+    titles = [p['title'] for p in data['posts']]
+    assert titles == ['Apple 0']
+
+    resp = client.get('/api/posts', query_string={'q': 'apple', 'limit': 0})
+    data = resp.get_json()
+    assert len(data['posts']) == 3


### PR DESCRIPTION
## Summary
- add `/api/posts` search endpoint with limit/offset pagination
- expose `/api/posts/<id>` GET and PUT for reading and updating posts and metadata
- document new API endpoints and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36671123883298a7908a80471d66a