### PR TITLE
Save search sentence as citation context

### DIFF
--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -348,6 +348,7 @@
                       saveBtn.addEventListener('click', () => {
                           const fd = new FormData();
                           fd.append('citation_text', c.text);
+                          fd.append('citation_context', sentence);
                           fetch('{{ url_for('new_citation', post_id=post.id) }}', {
                               method: 'POST',
                               body: fd

--- a/tests/test_suggest_citation_save.py
+++ b/tests/test_suggest_citation_save.py
@@ -42,12 +42,14 @@ def test_save_suggested_citation(client):
     with app.app_context():
         post_id = Post.query.filter_by(path='main').first().id
         bibtex = "@misc{123,\n  title={Reference},\n  url={/en/ref}\n}"
+    sentence = 'Reference is cited here.'
     resp = client.post(
         f'/post/{post_id}/citation/new',
-        data={'citation_text': bibtex},
+        data={'citation_text': bibtex, 'citation_context': sentence},
     )
     assert resp.status_code == 302
     with app.app_context():
         cit = PostCitation.query.filter_by(post_id=post_id).first()
         assert cit.citation_part['title'] == 'Reference'
         assert cit.citation_part['url'] == '/en/ref'
+        assert cit.context == sentence


### PR DESCRIPTION
## Summary
- Automatically include the searched sentence when saving suggested citations
- Test that saving a suggested citation stores its search sentence as context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a368402c008329b2f0131f88f13a23