### PR TITLE
Add MathJax rendering for Markdown content

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,12 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}" media="print">
   {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
+  <script>
+    window.MathJax = {
+      tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
+    };
+  </script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -146,6 +146,9 @@ function updatePreview() {
     noSpinner: true
   }).then(r => r.json()).then(data => {
     previewEl.innerHTML = data.html || '';
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      MathJax.typesetPromise([previewEl]);
+    }
   });
 }
 if (easyMDE && easyMDE.codemirror) {

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -47,6 +47,11 @@ def test_render_markdown_blank_numbered_item_becomes_unordered():
     assert '<li></li>' not in html
 
 
+def test_render_markdown_preserves_mathjax_delimiters():
+    html, _ = render_markdown('Euler formula $e^{i\\pi}+1=0$')
+    assert '$e^{i\\pi}+1=0$' in html
+
+
 @pytest.fixture
 def client():
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- Load MathJax globally and configure `$...$` inline math delimiters
- Render MathJax in Markdown previews for post editing
- Test that Markdown rendering preserves MathJax delimiters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36a096c5c8329a69fecafaf88b1c7