### PR TITLE
Allow single-space indents for nested Markdown lists

### DIFF
--- a/app.py
+++ b/app.py
@@ -773,12 +773,12 @@ def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> t
         PreserveOrderedListExtension(),
     ]
     if with_toc:
-        md = markdown.Markdown(extensions=extensions + ['toc'])
+        md = markdown.Markdown(extensions=extensions + ['toc'], tab_length=1)
         html = md.convert(text or '')
         if not getattr(md, 'toc_tokens', None):
             return html, ''
         return html, md.toc
-    html = markdown.markdown(text or '', extensions=extensions)
+    html = markdown.markdown(text or '', extensions=extensions, tab_length=1)
     return html, ''
 
 

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import app, render_markdown
@@ -50,6 +51,15 @@ def test_render_markdown_blank_numbered_item_becomes_unordered():
 def test_render_markdown_preserves_mathjax_delimiters():
     html, _ = render_markdown('Euler formula $e^{i\\pi}+1=0$')
     assert '$e^{i\\pi}+1=0$' in html
+
+
+def test_render_markdown_single_space_indented_list():
+    """A single leading space should create a nested list."""
+    html, _ = render_markdown('- a\n - b\n- c')
+    root = ET.fromstring(f'<root>{html}</root>')
+    outer = root.find('ul')
+    assert len(list(outer)) == 2
+    assert outer[0].find('ul') is not None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Render Markdown with `tab_length=1` so any extra space nests list items
- Test that a single leading space indents a nested list correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3768bd2c083299bcd31d30acb53cf