### PR TITLE
Enable Markdown table rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -814,6 +814,7 @@ def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> t
     extensions: list[Extension | str] = [
         WikiLinkExtension(base_url=base_url),
         PreserveOrderedListExtension(),
+        'tables',
     ]
     # Attempt to add automatic tag linking if tags are available
     try:

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -62,6 +62,13 @@ def test_render_markdown_single_space_indented_list():
     assert outer[0].find('ul') is not None
 
 
+def test_render_markdown_tables():
+    html, _ = render_markdown('| a | b |\n| - | - |\n| 1 | 2 |')
+    assert '<table>' in html
+    assert '<td>1</td>' in html
+    assert '<td>2</td>' in html
+
+
 @pytest.fixture
 def client():
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- Ensure Markdown tables render correctly by enabling the `tables` extension in the Markdown renderer
- Add unit test verifying table HTML output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37a2283448329aa4254ef78cdafb9