### PR TITLE
Ensure long words wrap in post body

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -185,7 +185,8 @@ textarea::placeholder,
 }
 
 #ogTitle,
-#ogDescription {
+#ogDescription,
+.post-body {
   word-break: break-word;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- Prevent overflow in post content by applying word-break and overflow-wrap rules to `.post-body`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a379d324e48329a3fab1cbbd5d474a