### PR TITLE
Fix tag tooltip hover and skip deleted posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -826,11 +826,13 @@ def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> t
                     'snippet': (p.body.splitlines()[0] if p.body else ''),
                 }
                 for p in tag.posts
+                if p.title and p.body
             ]
-            tag_map[tag.name.lower()] = {
-                'url': f"/tag/{quote(tag.name)}",
-                'tooltip': json.dumps(posts),
-            }
+            if posts:
+                tag_map[tag.name.lower()] = {
+                    'url': f"/tag/{quote(tag.name)}",
+                    'tooltip': json.dumps(posts),
+                }
         if tag_map:
             extensions.append(TagLinkExtension(tag_map))
     except Exception:

--- a/static/tag-tooltip.js
+++ b/static/tag-tooltip.js
@@ -27,8 +27,16 @@ document.addEventListener('DOMContentLoaded', () => {
     tooltip.style.display = 'none';
   }
 
+  function maybeHideTooltip(e) {
+    if (!tooltip.contains(e.relatedTarget)) {
+      hideTooltip();
+    }
+  }
+
   document.querySelectorAll('a.tag-link').forEach(el => {
     el.addEventListener('mouseenter', showTooltip);
-    el.addEventListener('mouseleave', hideTooltip);
+    el.addEventListener('mouseout', maybeHideTooltip);
   });
+
+  tooltip.addEventListener('mouseleave', hideTooltip);
 });


### PR DESCRIPTION
## Summary
- Keep tag tooltip visible while hovering over it
- Exclude deleted posts from tooltip data

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a37ab849188329a7997fbf546e56f9