### PR TITLE
Show borders for rendered tables

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -27,6 +27,15 @@ body {
   font-size: 10pt;
 }
 
+.post-body table {
+  border-collapse: collapse;
+}
+
+.post-body th,
+.post-body td {
+  border: 1px solid #000;
+}
+
 /* Map sizing for print */
 #map,
 #map-offcanvas,

--- a/static/style.css
+++ b/static/style.css
@@ -191,6 +191,15 @@ textarea::placeholder,
   overflow-wrap: anywhere;
 }
 
+.post-body table {
+  border-collapse: collapse;
+}
+
+.post-body th,
+.post-body td {
+  border: 1px solid var(--border-color);
+}
+
 pre {
   background-color: var(--nav-bg-color);
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- Add CSS to display borders for tables rendered in post content
- Ensure printed tables include cell borders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37c51a9448329afcbcb7447e7d928