### PR TITLE
Remove request size limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,6 +85,10 @@ app.config['BABEL_TRANSLATION_DIRECTORIES'] = os.getenv(
     'BABEL_TRANSLATION_DIRECTORIES', 'translations'
 )
 
+# Allow posts with very large bodies by disabling request size limits
+app.config['MAX_CONTENT_LENGTH'] = None
+app.config['MAX_FORM_MEMORY_SIZE'] = None
+
 db.init_app(app)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'

--- a/tests/test_large_post.py
+++ b/tests/test_large_post.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='editor', role='editor')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        client.post('/login', data={'username': 'editor', 'password': 'pw'})
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_creates_large_post(client):
+    large_body = 'A' * 600000
+    resp = client.post(
+        '/api/posts',
+        json={
+            'title': 'Big',
+            'body': large_body,
+            'path': 'big-post',
+            'language': 'en',
+        },
+    )
+    assert resp.status_code == 201
+    with app.app_context():
+        post = Post.query.filter_by(path='big-post', language='en').first()
+        assert post is not None
+        assert post.body == large_body


### PR DESCRIPTION
## Summary
- allow very large submissions by disabling Flask's request size limits
- add regression test ensuring large posts can be created via the API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3801cf7fc83298db65a0b94f930b1