### PR TITLE
Expand tag tooltip width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -375,7 +375,7 @@ footer a {
   padding: 0.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   z-index: 1000;
-  max-width: 300px;
+  max-width: 500px;
 }
 
 .tag-tooltip-card .tag-doc + .tag-doc {


### PR DESCRIPTION
## Summary
- increase tag tooltip card max width for better readability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a380489e208329a1455c1567289225