### PR TITLE
Allow setting home page path from domain root

### DIFF
--- a/app.py
+++ b/app.py
@@ -1046,14 +1046,16 @@ def all_posts():
 
 @app.route('/')
 def index():
-    home_path = get_setting('home_page_path', '').strip()
+    home_path = get_setting('home_page_path', '').strip().lstrip('/')
     if home_path:
-        language = select_locale() or app.config['BABEL_DEFAULT_LOCALE']
-        post = Post.query.filter_by(language=language, path=home_path).first()
+        if '/' in home_path:
+            language, doc_path = home_path.split('/', 1)
+        else:
+            language = select_locale() or app.config['BABEL_DEFAULT_LOCALE']
+            doc_path = home_path
+        post = Post.query.filter_by(language=language, path=doc_path).first()
         if post:
-            return redirect(
-                url_for('document_docs', language=language, doc_path=home_path)
-            )
+            return redirect(url_for('document', language=language, doc_path=doc_path))
     return all_posts()
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,6 +15,7 @@
     <div class="mb-3">
       <label for="home_page_path" class="form-label">{{ _('Home page path') }}</label>
       <input type="text" id="home_page_path" name="home_page_path" class="form-control" value="{{ home_page_path }}">
+      <div class="form-text">{{ _('Path from domain root, e.g. "en/home". Omit the language to use browser preference.') }}</div>
     </div>
     <div class="mb-3">
       <label for="timezone" class="form-label">{{ _('Timezone') }}</label>

--- a/tests/test_home_page_setting.py
+++ b/tests/test_home_page_setting.py
@@ -33,7 +33,7 @@ def test_home_page_redirect(client):
 
     resp = client.get('/')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/docs/en/home')
+    assert resp.headers['Location'].endswith('/en/home')
 
 
 def test_home_page_redirect_ko_locale(client):
@@ -55,7 +55,29 @@ def test_home_page_redirect_ko_locale(client):
 
     resp = client.get('/', headers={'Accept-Language': 'ko'})
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/docs/ko/spacetime')
+    assert resp.headers['Location'].endswith('/ko/spacetime')
+
+
+def test_home_page_with_language_in_setting(client):
+    with app.app_context():
+        user = User(username='author')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.commit()
+        post = Post(
+            title='Spacetime',
+            body='Content',
+            path='spacetime',
+            language='ko',
+            author=user,
+        )
+        db.session.add(post)
+        db.session.add(Setting(key='home_page_path', value='ko/spacetime'))
+        db.session.commit()
+
+    resp = client.get('/', headers={'Accept-Language': 'en'})
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/ko/spacetime')
 
 
 def test_updating_home_page_path_preserves_site_title(client):


### PR DESCRIPTION
## Summary
- Support `home_page_path` values including language prefix so the root page can redirect to a specific `/lang/path`
- Document home page path format in settings UI
- Test redirects when `home_page_path` includes language segment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38f4df384832993c2367d3283a6cc