### PR TITLE
Use $$ delimiters for MathJax

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,10 @@
   {{ get_setting('head_tags')|safe }}
   <script>
     window.MathJax = {
-      tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
+      tex: {
+        inlineMath: [['\\(', '\\)']],
+        displayMath: [['$$', '$$'], ['\\[', '\\]']]
+      }
     };
   </script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
## Summary
- Stop MathJax from treating single `$` as math delimiters
- Restrict inline math to `\(\)` and block math to `$$`/`\[\]`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3931c546483299362b843aaf4eb6c