### PR TITLE
Expand searches with English synonyms

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,7 @@ from flask import Blueprint, jsonify, request, current_app, url_for
 from flask_login import current_user, login_required
 from flask_babel import _
 from langdetect import detect, LangDetectException
+from search_utils import expand_with_synonyms
 
 from models import (
     db,
@@ -38,11 +39,12 @@ def search_posts():
 
     query = Post.query
     if q:
+        expanded_q = expand_with_synonyms(q)
         ids = [
             row[0]
             for row in db.session.execute(
                 text("SELECT rowid FROM post_fts WHERE post_fts MATCH :q"),
-                {"q": q},
+                {"q": expanded_q},
             )
         ]
         query = query.filter(Post.id.in_(ids)) if ids else query.filter(False)

--- a/app.py
+++ b/app.py
@@ -47,6 +47,7 @@ from geopy.distance import distance as geopy_distance
 from langdetect import detect, DetectorFactory, LangDetectException
 import zoneinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from search_utils import expand_with_synonyms
 
 from models import (
     db,
@@ -2494,11 +2495,12 @@ def search():
     posts_query = None
     examples = None
     if q:
+        expanded_q = expand_with_synonyms(q)
         ids = [
             row[0]
             for row in db.session.execute(
                 text('SELECT rowid FROM post_fts WHERE post_fts MATCH :q'),
-                {'q': q},
+                {'q': expanded_q},
             )
         ]
         posts_query = Post.query.filter(Post.id.in_(ids)) if ids else Post.query.filter(False)

--- a/search_utils.py
+++ b/search_utils.py
@@ -1,0 +1,42 @@
+"""Utilities for expanding search queries with synonyms.
+
+This module provides a small built-in English synonym map and a helper
+function to expand a user query so that searches will also match known
+synonyms.  The map intentionally remains tiny to keep the repository
+lightweight while demonstrating synonym expansion.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+# A minimal English synonym dictionary used for search expansion.
+# Only a handful of common terms are included to keep the dependency
+# footprint small.
+SYNONYM_MAP: Dict[str, List[str]] = {
+    "fast": ["quick", "rapid", "speedy"],
+    "quick": ["fast", "rapid", "speedy"],
+    "rapid": ["fast", "quick", "speedy"],
+    "speedy": ["fast", "quick", "rapid"],
+}
+
+
+def expand_with_synonyms(query: str) -> str:
+    """Expand a search query to include known synonyms.
+
+    Each word in the query is replaced with an ``OR`` group containing the
+    word itself and any synonyms from :data:`SYNONYM_MAP`.  This string is
+    suitable for use with SQLite's FTS ``MATCH`` operator.
+    """
+
+    tokens = re.findall(r"\w+", query)
+    parts: List[str] = []
+    for token in tokens:
+        synonyms = SYNONYM_MAP.get(token.lower())
+        if synonyms:
+            group = " OR ".join([token] + synonyms)
+            parts.append(f"({group})")
+        else:
+            parts.append(token)
+    return " ".join(parts) if parts else query

--- a/tests/test_api_search_posts.py
+++ b/tests/test_api_search_posts.py
@@ -48,3 +48,17 @@ def test_api_search_pagination(client):
     resp = client.get('/api/posts', query_string={'q': 'apple', 'limit': 0})
     data = resp.get_json()
     assert len(data['posts']) == 3
+
+
+def test_api_search_synonyms(client):
+    with app.app_context():
+        user = User.query.first()
+        p = Post(title='Quick Post', body='quick runner', path='psyn', language='en', author_id=user.id)
+        db.session.add(p)
+        db.session.commit()
+
+    resp = client.get('/api/posts', query_string={'q': 'fast'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    titles = [p['title'] for p in data['posts']]
+    assert 'Quick Post' in titles

--- a/tests/test_search_fts.py
+++ b/tests/test_search_fts.py
@@ -26,7 +26,8 @@ def client():
         p1.tags.append(t1)
         p2 = Post(title='Banana', body='banana carrot', path='p2', language='en', author_id=user.id)
         p2.tags.append(t2)
-        db.session.add_all([p1, p2])
+        p3 = Post(title='Speed', body='quick movement', path='p3', language='en', author_id=user.id)
+        db.session.add_all([p1, p2, p3])
         db.session.commit()
     with app.test_client() as client:
         yield client
@@ -47,3 +48,9 @@ def test_tag_filter(client):
     text = resp.get_data(as_text=True)
     assert 'Apple' in text
     assert 'Banana' not in text
+
+
+def test_fulltext_synonym_search(client):
+    resp = client.get('/search', query_string={'q': 'fast'})
+    text = resp.get_data(as_text=True)
+    assert 'Speed' in text


### PR DESCRIPTION
## Summary
- expand search queries using built-in synonym dictionary
- apply synonym expansion to API search endpoint
- add tests verifying synonym search behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39448e6a8832999db3d0941317203