### PR TITLE
docs: document third-party libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ pip install -r requirements.txt
 The application uses the Crossref API through the `habanero` library, so network
 access is required when querying Crossref.
 
+## Dependencies
+
+A summary of third-party libraries used in Spacetime is available in [docs/LIBRARIES.md](docs/LIBRARIES.md).
+
 ## Configuration
 Create a `.env` file in the project root to configure runtime settings. The
 following variables are supported:

--- a/docs/LIBRARIES.md
+++ b/docs/LIBRARIES.md
@@ -1,0 +1,22 @@
+# 사용 라이브러리 정리
+
+이 문서는 Spacetime 프로젝트에서 사용되는 주요 파이썬 라이브러리를 정리합니다.
+
+## 기본 의존성
+
+- **bibtexparser** — BibTeX 데이터를 파싱하기 위한 라이브러리.
+- **Flask** — 애플리케이션의 기본 웹 프레임워크.
+- **Flask-Babel** — 다국어 지원과 번역 기능.
+- **Flask-Login** — 사용자 인증과 세션 관리.
+- **Flask-SQLAlchemy** — 데이터베이스 ORM.
+- **Flask-SocketIO** — WebSocket 기반 실시간 기능.
+- **geopy** — 지오코딩 등 위치 기반 기능.
+- **habanero** — Crossref API 연동.
+- **langdetect** — 텍스트 언어 감지.
+- **markdown** — Markdown을 HTML로 변환.
+- **python-dotenv** — .env 파일에서 환경 변수 로딩.
+- **redis** — 캐시 및 메시지 큐.
+- **requests** — HTTP 클라이언트.
+- **tzdata** — 최신 시간대 데이터.
+- **nltk** — 자연어 처리 도구 모음.
+


### PR DESCRIPTION
## Summary
- document third-party libraries used by Spacetime
- link README to new library documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39e881924832983b15f5e27058f9b