### PR TITLE
Respect dark mode for light background elements

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -107,6 +107,11 @@ nav a {
   border-color: var(--border-color) !important;
 }
 
+.bg-light {
+  background-color: var(--nav-bg-color) !important;
+  color: var(--text-color) !important;
+}
+
 a {
   color: var(--link-color);
   text-decoration-color: var(--link-color);


### PR DESCRIPTION
## Summary
- ensure `.bg-light` elements use theme variables so suggestion boxes and similar components match dark mode

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3a02a5b708329aa13a07c8787ee08