### PR TITLE
Remove tag list from tag map view

### DIFF
--- a/app.py
+++ b/app.py
@@ -2443,7 +2443,6 @@ def tag_list():
         .all()
     )
     tag_locations = []
-    tag_info = []
     tag_posts_data = []
     location_counts = {}
     for tag in tags:
@@ -2486,7 +2485,6 @@ def tag_list():
             key=lambda x: x[1],
             reverse=True,
         )[:3]
-        tag_info.append({'tag': tag, 'top_posts': top_posts})
         posts_data = []
         for p, _ in top_posts:
             snippet = (p.body[:100] + '...') if len(p.body) > 100 else p.body
@@ -2504,7 +2502,6 @@ def tag_list():
     tag_posts_json = json.dumps(tag_posts_data)
     return render_template(
         'tag_list.html',
-        tag_info=tag_info,
         tag_locations_json=tag_locations_json,
         tag_posts_json=tag_posts_json,
         tag_modal_new_tab=(

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -5,7 +5,6 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css" />
 <style>
-  .container { max-width: 100% !important; margin: 0 !important; padding: 0 !important; }
   #tag-info-content a { text-decoration: none; }
   #tag-info-content h3 a { text-decoration: underline; }
   .marker-cluster {
@@ -33,25 +32,6 @@
 </div>
 <input type="search" id="tag-search" class="form-control" placeholder="{{ _('Search tags...') }}">
 <div id="tag-map"></div>
-<div class="container mt-4">
-  {% for info in tag_info %}
-    <div class="tag-card">
-      <h5>
-        <a href="{{ url_for('tag_filter', name=info.tag.name) }}" class="tag-pill">{{ info.tag.name }}</a>
-      </h5>
-      {% if info.top_posts %}
-        <ul>
-          {% for post, views in info.top_posts %}
-            <li>
-              <a href="{{ url_for('document', language=post.language, doc_path=post.path) }}">{{ post.display_title }}</a>
-              <span class="small text-muted">· {{ views }} {{ _('views') }}</span>
-            </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    </div>
-  {% endfor %}
-</div>
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- remove tag list container between navbar and map on tags page
- drop unused tag_info data from route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a4012fb88329b89eb5d5273ae3de