### PR TITLE
Add SEO metadata and robots.txt support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1151,6 +1151,16 @@ def rss_feed():
     return Response(xml, mimetype='application/rss+xml')
 
 
+@app.route('/robots.txt')
+def robots_txt():
+    lines = [
+        'User-agent: *',
+        'Disallow:',
+        f"Sitemap: {url_for('sitemap', _external=True)}",
+    ]
+    return Response("\n".join(lines), mimetype='text/plain')
+
+
 @app.route('/sitemap.xml')
 def sitemap():
     """Generate a basic XML sitemap of all posts."""
@@ -1581,6 +1591,8 @@ def post_detail(post_id: int):
     base = url_for('document', language=post.language, doc_path='')
     html_body, toc = render_markdown(post.body, base, with_toc=True)
     canonical_url = url_for('document', language=post.language, doc_path=post.path, _external=True)
+    plain = re.sub('<[^<]+?>', '', html_body)
+    meta_description = ' '.join(plain.split())[:160]
     year = created_at.year if created_at else datetime.utcnow().year
     key = re.sub(r'\W+', '', f"{post.author.username}{year}{post.id}")
     bibtex = (
@@ -1605,6 +1617,7 @@ def post_detail(post_id: int):
         address=address,
         bibtex=bibtex,
         canonical_url=canonical_url,
+        meta_description=meta_description,
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='print.css') }}" media="print">
+  {% if meta_description %}
+  <meta name="description" content="{{ meta_description }}">
+  {% endif %}
+  <link rel="canonical" href="{{ canonical_url|default(request.url, true) }}">
   {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
   <script>

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_robots_txt(client):
+    resp = client.get('/robots.txt')
+    assert resp.status_code == 200
+    assert b'Sitemap:' in resp.data


### PR DESCRIPTION
## Summary
- Include meta description and canonical URL in base template for better SEO
- Compute meta description from post content and expose robots.txt linking to sitemap
- Test robots.txt route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a4a4a6008329b21a9a422019172e