### PR TITLE
Center citation stats pagination

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -26,7 +26,7 @@
   {% endfor %}
   </table>
 <nav>
-  <ul class="pagination">
+  <ul class="pagination justify-content-center mt-4">
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('citation_stats', page=pagination.prev_num) }}">&laquo;</a>
     </li>


### PR DESCRIPTION
## Summary
- Center pagination on the citation statistics page for consistent layout

## Testing
- `pytest tests/test_citation_stats_pagination.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a74ec4108329ac82b16e0dc5048b