### PR TITLE
Ensure tag modal stays in view and show nearby popular posts

### DIFF
--- a/app.py
+++ b/app.py
@@ -2493,20 +2493,51 @@ def tag_list():
                     'url': url_for('tag_filter', name=tag.name),
                 }
             )
-        top_posts = sorted(
-            [(p, get_view_count(p)) for p in tag.posts if p.title and p.body],
-            key=lambda x: x[1],
-            reverse=True,
-        )[:3]
+        def haversine(lat1, lon1, lat2, lon2):
+            r = 6371
+            p1 = math.radians(lat1)
+            p2 = math.radians(lat2)
+            dphi = math.radians(lat2 - lat1)
+            dlambda = math.radians(lon2 - lon1)
+            a = (
+                math.sin(dphi / 2) ** 2
+                + math.cos(p1) * math.cos(p2) * math.sin(dlambda / 2) ** 2
+            )
+            return 2 * r * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+        scored_posts = []
+        for p in tag.posts:
+            if not p.title or not p.body:
+                continue
+            views = get_view_count(p)
+            plat, plon = p.latitude, p.longitude
+            if plat is None or plon is None:
+                meta = {m.key: m.value for m in p.metadata}
+                plat = meta.get('lat') or meta.get('latitude')
+                plon = meta.get('lon') or meta.get('longitude')
+                if plat is not None and plon is not None:
+                    try:
+                        plat = float(plat)
+                        plon = float(plon)
+                    except ValueError:
+                        plat = plon = None
+            distance = (
+                haversine(lat, lon, plat, plon)
+                if coords is not None and plat is not None and plon is not None
+                else float('inf')
+            )
+            snippet = (p.body[:150] + '...') if len(p.body) > 150 else p.body
+            scored_posts.append((distance, views, p, snippet))
+
+        scored_posts.sort(key=lambda x: (0 if x[0] <= 100 else 1, -x[1], x[0]))
         posts_data = []
-        for p, _ in top_posts:
-            snippet = (p.body[:100] + '...') if len(p.body) > 100 else p.body
+        for distance, views, p, snippet in scored_posts[:5]:
             posts_data.append(
                 {
                     'title': p.display_title,
                     'url': url_for('document', language=p.language, doc_path=p.path),
                     'snippet': snippet,
-                    'views': get_view_count(p),
+                    'views': views,
                     'author': p.author.username,
                 }
             )

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -55,6 +55,27 @@ searchInput.style.left = '10px';
 searchInput.style.zIndex = '1000';
 searchInput.style.maxWidth = '250px';
 
+function ensureInfoInViewport(){
+  const margin = 10;
+  const rect = infoDiv.getBoundingClientRect();
+  let left = rect.left;
+  let top = rect.top;
+  if(rect.right > window.innerWidth - margin){
+    left = window.innerWidth - rect.width - margin;
+  }
+  if(left < margin){
+    left = margin;
+  }
+  if(rect.bottom > window.innerHeight - margin){
+    top = window.innerHeight - rect.height - margin;
+  }
+  if(top < navHeight){
+    top = navHeight;
+  }
+  infoDiv.style.left = left + 'px';
+  infoDiv.style.top = top + 'px';
+}
+
 function positionInfoDiv(){
   if(infoDiv.dataset.dragged === 'true') return;
   infoDiv.style.position = 'fixed';
@@ -82,6 +103,7 @@ function positionInfoDiv(){
     infoDiv.style.borderRadius = '0';
     infoDiv.style.boxShadow = 'none';
   }
+  ensureInfoInViewport();
 }
 
 positionInfoDiv();
@@ -107,6 +129,7 @@ dragHandle.addEventListener('mousedown', (e) => {
 document.addEventListener('mouseup', () => {
   isDragging = false;
   document.removeEventListener('mousemove', onMouseMove);
+  ensureInfoInViewport();
 });
 
 function onMouseMove(e){
@@ -177,6 +200,7 @@ const allMarkers = [];
         infoDiv.style.display = 'block';
         infoDiv.dataset.dragged = 'false';
         positionInfoDiv();
+        ensureInfoInViewport();
       }
     });
     marker.tagName = t.name;


### PR DESCRIPTION
## Summary
- keep tag info modal within the visible window, even after resizing or dragging
- expand tag preview to five posts sorted by proximity and view count for better local context
- test tag preview ordering for nearby high-view posts

## Testing
- `pytest tests/test_tags_map.py::test_tag_preview_prioritizes_nearby_high_views -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a9b68ec08329a420a7e38be127c5