### PR TITLE
Ensure map controls visible on tag page

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -51,7 +51,8 @@ const searchInput = document.getElementById('tag-search');
 
 searchInput.style.position = 'fixed';
 searchInput.style.top = navHeight + 10 + 'px';
-searchInput.style.left = '10px';
+searchInput.style.right = '10px';
+searchInput.style.left = 'auto';
 searchInput.style.zIndex = '1000';
 searchInput.style.maxWidth = '250px';
 


### PR DESCRIPTION
## Summary
- Move tag search box to top-right so default map controls remain visible

## Testing
- `pytest` *(fails: tests/test_tags_map.py::test_tag_preview_prioritizes_nearby_high_views)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ad626c80832982cfe3e7cdea71fe