### PR TITLE
Fix tag modal overflow on tag list page

### DIFF
--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -88,8 +88,7 @@ function positionInfoDiv(){
   if(window.innerWidth >= 768){
     const width = 400;
     infoDiv.style.width = width + 'px';
-    const mapRect = mapDiv.getBoundingClientRect();
-    infoDiv.style.left = (mapRect.right - width - 10) + 'px';
+    infoDiv.style.left = (window.innerWidth - width - 10) + 'px';
     infoDiv.style.right = 'auto';
     infoDiv.style.maxHeight = '50vh';
     infoDiv.style.border = '1px solid rgba(0,0,0,0.1)';


### PR DESCRIPTION
## Summary
- Prevent tag info modal from rendering off-screen by computing left position using viewport width

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b0d463ec83299c9665b88817edac