### PR TITLE
Add bulk citation deletion from stats page

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -14,6 +14,11 @@
         <a href="https://scholar.google.com/scholar?q={{ item.citation_text | urlencode }}">{{ item.citation_text }}</a>
       {% endif %}
       ({{ item.count }})
+      <form method="post" action="{{ url_for('delete_citation_everywhere') }}" class="d-inline ms-2" onsubmit="return confirm('{{ _('Are you sure?') }}');">
+        <input type="hidden" name="doi" value="{{ item.doi | default('') }}" />
+        <input type="hidden" name="citation_text" value="{{ item.citation_text }}" />
+        <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>
+      </form>
     </td>
   </tr>
   <tr>

--- a/tests/test_citation_stats_delete.py
+++ b/tests/test_citation_stats_delete.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        db.session.add(admin)
+        post1 = Post(title='P1', body='Body', path='p1', language='en', author=admin)
+        post2 = Post(title='P2', body='Body', path='p2', language='en', author=admin)
+        db.session.add_all([post1, post2])
+        db.session.commit()
+        for post in (post1, post2):
+            db.session.add(PostCitation(
+                post_id=post.id,
+                user_id=admin.id,
+                citation_part={'title': 't'},
+                citation_text='Cite Me',
+                context='',
+                doi='10.1234/abc',
+                bibtex_raw='@article{a}',
+                bibtex_fields={'title': 't'},
+            ))
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_delete_citation_everywhere(client):
+    client.post('/login', data={'username': 'admin', 'password': 'pw'})
+    resp = client.get('/citations/stats')
+    assert b'Cite Me' in resp.data
+    resp = client.post(
+        '/citations/delete',
+        data={'doi': '10.1234/abc', 'citation_text': 'Cite Me'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    resp = client.get('/citations/stats')
+    assert b'Cite Me' not in resp.data
+    with app.app_context():
+        assert PostCitation.query.count() == 0


### PR DESCRIPTION
## Summary
- add backend route to delete a citation across all posts
- show delete button on citation stats page
- test removing citations from stats

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3b134f9e8832988790c8b2789699a