### PR TITLE
Keep navbar fixed and adjust tag map popups

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -62,6 +62,9 @@ nav a {
 }
 
 .navbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
   background-color: var(--nav-bg-color) !important;
 }
 

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -36,6 +36,7 @@
 <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
 <script>
 const navHeight = document.querySelector('nav').offsetHeight;
+document.body.style.overflow = 'hidden';
 const mapDiv = document.getElementById('tag-map');
 mapDiv.style.position = 'fixed';
 mapDiv.style.top = navHeight + 'px';
@@ -238,6 +239,12 @@ searchInput.addEventListener('keyup', () => {
   });
   if (term && matches.length) {
     map.setView(matches[0].getLatLng(), 8);
+  }
+});
+
+map.on('move', () => {
+  if (lastMarker) {
+    positionInfoDivNearMarker(lastMarker);
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- Make navbar sticky so it doesn't scroll with the page
- Disable body scroll and reposition tag info popup relative to map moves

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c7e2e8948329b2c4fca372965a35