### PR TITLE
Add map previews to tag hover cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -386,6 +386,21 @@ footer a {
   max-width: 500px;
 }
 
+.tag-tooltip-card .tag-doc {
+  display: flex;
+}
+
+.tag-tooltip-card .tooltip-map {
+  width: 120px;
+  height: 80px;
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+}
+
+.tag-tooltip-card .tag-doc-text {
+  flex: 1;
+}
+
 .tag-tooltip-card .tag-doc + .tag-doc {
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- include post coordinates in tag tooltip metadata
- load Leaflet on demand and render small maps in tag hover cards
- style tooltip layout to fit map beside title and snippet

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3cae53fbc8329a6dfcdba1affcf45