### PR TITLE
Normalize newline handling for citation deletions

### DIFF
--- a/app.py
+++ b/app.py
@@ -2809,6 +2809,9 @@ def delete_citation_everywhere():
     doi = request.form.get('doi')
     citation_text = request.form.get('citation_text')
 
+    if citation_text is not None:
+        citation_text = citation_text.replace('\r\n', '\n')
+
     query = PostCitation.query.filter_by(citation_text=citation_text)
     user_query = UserPostCitation.query.filter_by(citation_text=citation_text)
     if doi:

--- a/tests/test_citation_stats_delete_newline.py
+++ b/tests/test_citation_stats_delete_newline.py
@@ -46,6 +46,7 @@ def test_delete_citation_with_newline(client):
     m = re.search(r'<textarea name="citation_text"[^>]*>(.*?)</textarea>', html, re.S)
     assert m is not None
     value = m.group(1)
+    value = value.replace('\n', '\r\n')
     client.post(
         '/citations/delete',
         data={'doi': '10.1234/abc', 'citation_text': value},


### PR DESCRIPTION
## Summary
- Normalize Windows-style CRLF line endings when deleting citations across posts
- Add regression test ensuring `/citations/delete` works when form submissions send CRLF newlines

## Testing
- `pytest tests/test_citation_stats_delete_newline.py::test_delete_citation_with_newline -q`
- `pytest -q` *(fails: tests/test_tags_map.py::test_tag_preview_prioritizes_nearby_high_views)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c9f0fa4883299c6d3a5fae5cfc6b