### PR TITLE
fix: keep tag tooltip within viewport

### DIFF
--- a/static/tag-tooltip.js
+++ b/static/tag-tooltip.js
@@ -59,8 +59,27 @@ document.addEventListener('DOMContentLoaded', () => {
     clearTimeout(hideTimeout);
     tooltip.style.display = 'block';
     const rect = this.getBoundingClientRect();
-    tooltip.style.left = `${rect.left + window.scrollX}px`;
-    tooltip.style.top = `${rect.bottom + window.scrollY + 5}px`;
+    let left = rect.left + window.scrollX;
+    let top = rect.bottom + window.scrollY + 5;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+
+    const margin = 10;
+    const tipRect = tooltip.getBoundingClientRect();
+    if (tipRect.right > window.innerWidth - margin) {
+      left -= tipRect.right - (window.innerWidth - margin);
+    }
+    if (left < margin) {
+      left = margin;
+    }
+    if (tipRect.bottom > window.innerHeight - margin) {
+      top -= tipRect.bottom - (window.innerHeight - margin);
+    }
+    if (top < margin) {
+      top = margin;
+    }
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
 
     const maps = tooltip.querySelectorAll('.tooltip-map');
     if (maps.length > 0) {


### PR DESCRIPTION
## Summary
- ensure tag tooltips reposition to remain inside the viewport when hovering over tags

## Testing
- `pytest` *(fails: tests/test_tags_map.py::test_tag_preview_prioritizes_nearby_high_views)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ce4b2f0c8329990a774b6a480126