### PR TITLE
Expand hover card map view

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -391,8 +391,8 @@ footer a {
 }
 
 .tag-tooltip-card .tooltip-map {
-  width: 120px;
-  height: 80px;
+  width: 150px;
+  height: 100px;
   margin-right: 0.5rem;
   flex-shrink: 0;
 }

--- a/static/tag-tooltip.js
+++ b/static/tag-tooltip.js
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
     }).addTo(map);
-    map.setView([lat, lon], 13);
+    map.setView([lat, lon], 11);
   }
 
   function showTooltip() {


### PR DESCRIPTION
## Summary
- enlarge map preview in tag hover tooltip for better visibility
- decrease default zoom level so a broader area is shown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ce7cf300832991a3bb0ca336c0cb