### PR TITLE
Improve tag hover card map text wrapping

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -387,22 +387,19 @@ footer a {
 }
 
 .tag-tooltip-card .tag-doc {
-  display: flex;
+  display: flow-root;
 }
 
 .tag-tooltip-card .tooltip-map {
   width: 120px;
   height: 80px;
   margin-right: 0.5rem;
-  flex-shrink: 0;
-}
-
-.tag-tooltip-card .tag-doc-text {
-  flex: 1;
+  float: left;
 }
 
 .tag-tooltip-card .tag-doc + .tag-doc {
   margin-top: 0.5rem;
+  clear: both;
 }
 
 .tag-tooltip-card p {


### PR DESCRIPTION
## Summary
- Allow tag tooltip text to wrap around the preview map for better use of space

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3cf643f408329b256b1966a075731