### PR TITLE
Add installation script and document NLTK setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,22 @@ Simple wiki-style bulletin board built with Flask and SQLite. Supports user regi
 - Permissions: authors or admins can edit posts
 
 ## Installation
-Install dependencies:
+Use the provided script to install all dependencies and download the complete
+NLTK dataset:
+
 ```bash
-pip install -r requirements.txt
+./install.sh
 ```
+
+If you prefer to perform the steps manually, install the required packages and
+download the NLTK resources yourself:
+
+```bash
+python -m pip install -r requirements.txt
+python -m nltk.downloader all
+```
+
+See [docs/INSTALLATION.md](docs/INSTALLATION.md) for additional details.
 
 The application uses the Crossref API through the `habanero` library, so network
 access is required when querying Crossref.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,19 @@
+# Installation Guide
+
+Run the provided script to install all dependencies and download NLTK data:
+
+```bash
+./install.sh
+```
+
+The script installs packages listed in `requirements.txt` and executes
+`nltk.download('all')` to fetch the complete NLTK dataset.
+
+If you prefer to run the commands manually:
+
+```bash
+python -m pip install -r requirements.txt
+python -m nltk.downloader all
+```
+
+Refer to the [README](../README.md) for configuration and usage details.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install Python dependencies and download all NLTK datasets.
+set -e
+
+python -m pip install -r requirements.txt
+python - <<'PY'
+import nltk
+nltk.download('all')
+PY


### PR DESCRIPTION
## Summary
- add install.sh to install requirements and download all NLTK data
- document installation in README and new docs/INSTALLATION.md

## Testing
- `pytest` *(fails: command was interrupted after hanging)*
- `pytest tests/test_markdown_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d44dba388329b8b1bfa69b09a288