### PR TITLE
Show DB performance statistics on admin status page

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,7 +7,7 @@ This document lists the HTTP endpoints provided by the Spacetime application.
 | `/` | `GET` | Home page listing posts or redirect to configured start page |
 | `/admin/posts` | `GET` | List posts for administrators |
 | `/admin/requested` | `GET, POST` | Manage user requested posts |
-| `/admin/db-status` | `GET` | View database status for administrators |
+| `/admin/db-status` | `GET` | View database status and performance statistics for administrators |
 | `/citation/fetch` | `POST` | Fetch citation metadata by DOI |
 | `/citation/suggest` | `POST` | Suggest citations for provided text |
 | `/citation/suggest_line` | `POST` | Return citation suggestions for a single line of text |

--- a/templates/admin/db_status.html
+++ b/templates/admin/db_status.html
@@ -11,4 +11,15 @@
     {% endfor %}
   </tbody>
 </table>
+{% if perf %}
+<h2>{{ _('Performance Stats') }}</h2>
+<table class="table table-striped">
+  <thead><tr><th>{{ _('Metric') }}</th><th>{{ _('Value') }}</th></tr></thead>
+  <tbody>
+    {% for key, value in perf.items() %}
+    <tr><td>{{ key }}</td><td>{{ value }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 {% endblock %}

--- a/tests/test_admin_db_status.py
+++ b/tests/test_admin_db_status.py
@@ -33,6 +33,8 @@ def test_admin_can_view_db_status(client):
     assert resp.status_code == 200
     assert b'user' in resp.data
     assert b'post' in resp.data
+    assert b'page_size' in resp.data
+    assert b'page_count' in resp.data
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Gather SQLite performance metrics (page size, page count, etc.) for `/admin/db-status`
- Display metrics on admin database status template
- Document availability in API docs and test for presence

## Testing
- `pytest tests/test_admin_db_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d48cf5208329ac378b8d266be835