### PR TITLE
Display view counts in tag hover cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -877,6 +877,7 @@ def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> t
                     'title': p.display_title,
                     'url': f"/{p.language}/{p.path}",
                     'snippet': (p.body.splitlines()[0] if p.body else ''),
+                    'views': get_view_count(p),
                 }
                 lat = p.latitude
                 lon = p.longitude

--- a/static/style.css
+++ b/static/style.css
@@ -384,6 +384,22 @@ footer a {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   z-index: 1000;
   max-width: 500px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.tag-tooltip-card::-webkit-scrollbar {
+  width: 6px;
+}
+.tag-tooltip-card::-webkit-scrollbar-track {
+  background: var(--nav-bg-color);
+}
+.tag-tooltip-card::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 3px;
+}
+.tag-tooltip-card::-webkit-scrollbar-thumb:hover {
+  background: #555;
 }
 
 .tag-tooltip-card .tag-doc {

--- a/static/tag-tooltip.js
+++ b/static/tag-tooltip.js
@@ -53,7 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const mapDiv = d.lat !== undefined && d.lon !== undefined
           ? `<div class="tooltip-map" id="tooltip-map-${i}" data-lat="${d.lat}" data-lon="${d.lon}"></div>`
           : '';
-        return `<div class="tag-doc">${mapDiv}<div class="tag-doc-text"><a href="${d.url}">${d.title}</a><p>${d.snippet}</p></div></div>`;
+        const views = d.views !== undefined ? `<div class="small text-muted">${d.views} views</div>` : '';
+        return `<div class="tag-doc">${mapDiv}<div class="tag-doc-text"><a href="${d.url}">${d.title}</a>${views}<p>${d.snippet}</p></div></div>`;
       })
       .join('');
     clearTimeout(hideTimeout);


### PR DESCRIPTION
## Summary
- include view counts in tag tooltip data and display
- make tag hover card scrollable with styled scrollbar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3d690dc3c8329aa435350289d4753