### PR TITLE
fix: support multiline math blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -857,6 +857,16 @@ def sanitize_tag_links(html: str) -> str:
     return ''.join(tostring(child, encoding='unicode') for child in root)
 
 
+def unwrap_math_blocks(html: str) -> str:
+    """Remove paragraph wrappers around display-math blocks.
+
+    Markdown wraps ``$$`` blocks in ``<p>`` tags which prevents MathJax from
+    recognizing multi-line display formulas. Unwrap those paragraphs so that
+    MathJax sees the raw ``$$`` delimiters.
+    """
+    return re.sub(r'<p>\s*(\$\$[\s\S]*?\$\$)\s*</p>', r'\1', html)
+
+
 # Markup rendering helpers
 def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> tuple[str, str]:
     """Return HTML and optional TOC from Markdown text with wiki links."""
@@ -917,11 +927,13 @@ def render_markdown(text: str, base_url: str = '/', with_toc: bool = False) -> t
         md = markdown.Markdown(extensions=extensions + ['toc'], tab_length=1)
         html = md.convert(normalized)
         html = sanitize_tag_links(html)
+        html = unwrap_math_blocks(html)
         if not getattr(md, 'toc_tokens', None):
             return html, ''
         return html, md.toc
     html = markdown.markdown(normalized, extensions=extensions, tab_length=1)
     html = sanitize_tag_links(html)
+    html = unwrap_math_blocks(html)
     return html, ''
 
 

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -53,6 +53,11 @@ def test_render_markdown_preserves_mathjax_delimiters():
     assert '$e^{i\\pi}+1=0$' in html
 
 
+def test_render_markdown_preserves_multiline_mathjax():
+    html, _ = render_markdown('$$\n\\int_0^1 x\\,dx\n$$')
+    assert html.strip() == '$$\n\\int_0^1 x\\,dx\n$$'
+
+
 def test_render_markdown_single_space_indented_list():
     """A single leading space should create a nested list."""
     html, _ = render_markdown('- a\n - b\n- c')


### PR DESCRIPTION
## Summary
- ensure markdown output preserves multi-line `$$` math blocks for MathJax
- test multiline math handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3d885ad8c83299d0d83d8358f5fb9