### PR TITLE
Fix citation stats bulk delete form submission

### DIFF
--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -16,7 +16,7 @@
       ({{ item.count }})
       <form method="post" action="{{ url_for('delete_citation_everywhere') }}" class="d-inline ms-2" onsubmit="return confirm('{{ _('Are you sure?') }}');">
         <input type="hidden" name="doi" value="{{ item.doi | default('') }}" />
-        <textarea name="citation_text" hidden>{{- item.citation_text -}}</textarea>
+        <textarea name="citation_text" class="d-none">{{- item.citation_text -}}</textarea>
         <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>
       </form>
     </td>


### PR DESCRIPTION
## Summary
- Ensure citation text field is submitted by replacing `hidden` textarea with `d-none`

## Testing
- `pytest tests/test_citation_stats_delete.py tests/test_citation_stats_delete_newline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3da8f98b08329b9c55943ffff9b7b