### PR TITLE
Skip tag links inside LaTeX

### DIFF
--- a/app.py
+++ b/app.py
@@ -854,7 +854,21 @@ def sanitize_tag_links(html: str) -> str:
                     prev = list(outer)[idx - 1]
                     prev.tail = (prev.tail or '') + text
                 outer.remove(inner)
-    return ''.join(tostring(child, encoding='unicode') for child in root)
+    cleaned = ''.join(tostring(child, encoding='unicode') for child in root)
+
+    def strip_links(match: re.Match) -> str:
+        segment = match.group(0)
+        return re.sub(
+            r'<a[^>]*class="tag-link"[^>]*>(.*?)</a>',
+            r'\1',
+            segment,
+            flags=re.DOTALL,
+        )
+
+    cleaned = re.sub(r'\$\$.*?\$\$', strip_links, cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r'\\\(.*?\\\)', strip_links, cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r'\\\[.*?\\\]', strip_links, cleaned, flags=re.DOTALL)
+    return cleaned
 
 
 def unwrap_math_blocks(html: str) -> str:

--- a/tests/test_tag_links_in_latex.py
+++ b/tests/test_tag_links_in_latex.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import app as app_module
+from app import app, render_markdown
+
+
+def test_tag_links_skipped_inside_latex(monkeypatch):
+    post = SimpleNamespace(
+        title='foo',
+        body='body',
+        display_title='foo',
+        language='en',
+        path='foo',
+        metadata=[],
+        latitude=None,
+        longitude=None,
+    )
+
+    class DummyQuery:
+        def all(self):
+            return [SimpleNamespace(name='foo', posts=[post])]
+
+    monkeypatch.setattr(app_module, 'Tag', SimpleNamespace(query=DummyQuery()))
+    monkeypatch.setattr(app_module, 'get_tag_synonyms', lambda name: {name})
+
+    with app.app_context():
+        html, _ = render_markdown('$$foo$$ and foo')
+
+    assert 'class="tag-link"' in html
+    assert '$$<a' not in html
+    assert '$$foo$$' in html


### PR DESCRIPTION
## Summary
- Prevent automatic tag linking inside LaTeX expressions by stripping tag links from math regions
- Add regression test to ensure tag links are skipped within LaTeX blocks

## Testing
- `pytest tests/test_tag_links_in_latex.py tests/test_latex_auto_detect.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3de421da883299d6bda115c84afde