### PR TITLE
Handle nested LaTeX in parentheses

### DIFF
--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -9,3 +9,11 @@ def test_parenthesized_latex_converted():
     with app.app_context():
         html, _ = render_markdown(r"Equation (\min\max_a) test")
     assert "$$\\min\\max_a$$" in html
+
+
+def test_nested_parenthesized_latex_converted():
+    with app.app_context():
+        html, _ = render_markdown(
+            r"Substitutes, (U(x_{1},x_{2})=a x_{1}+b x_{2}), test"
+        )
+    assert "$$U(x_{1},x_{2})=a x_{1}+b x_{2}$$" in html

--- a/tests/test_tag_links_in_latex.py
+++ b/tests/test_tag_links_in_latex.py
@@ -33,3 +33,30 @@ def test_tag_links_skipped_inside_latex(monkeypatch):
     assert 'class="tag-link"' in html
     assert '$$<a' not in html
     assert '$$foo$$' in html
+
+
+def test_tag_links_skipped_inside_detected_latex(monkeypatch):
+    post = SimpleNamespace(
+        title='foo',
+        body='body',
+        display_title='foo',
+        language='en',
+        path='foo',
+        metadata=[],
+        latitude=None,
+        longitude=None,
+    )
+
+    class DummyQuery:
+        def all(self):
+            return [SimpleNamespace(name='foo', posts=[post])]
+
+    monkeypatch.setattr(app_module, 'Tag', SimpleNamespace(query=DummyQuery()))
+    monkeypatch.setattr(app_module, 'get_tag_synonyms', lambda name: {name})
+
+    with app.app_context():
+        html, _ = render_markdown('(foo(x_{1},x_{2})=a x_{1}+b x_{2}) and foo')
+
+    assert 'class="tag-link"' in html
+    assert '$$<a' not in html
+    assert '$$foo(x_{1},x_{2})=a x_{1}+b x_{2}$$' in html


### PR DESCRIPTION
## Summary
- Expand LaTeX detection to handle nested parenthesized expressions and convert them to `$$` blocks
- Ensure tag linking is skipped inside auto-detected LaTeX
- Add regression tests for complex parenthesized LaTeX and tag link sanitization

## Testing
- `pytest tests/test_latex_auto_detect.py tests/test_tag_links_in_latex.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3e3c3953c832988edcfae6e0c9147