### PR TITLE
Fix nested LaTeX parentheses detection

### DIFF
--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -17,3 +17,11 @@ def test_nested_parenthesized_latex_converted():
             r"Substitutes, (U(x_{1},x_{2})=a x_{1}+b x_{2}), test"
         )
     assert "$$U(x_{1},x_{2})=a x_{1}+b x_{2}$$" in html
+
+
+def test_double_parenthesized_latex_converted():
+    """Ensure outer nested parentheses are fully stripped."""
+
+    with app.app_context():
+        html, _ = render_markdown(r"Coordinates ((x_{1}, x_{2})) test")
+    assert "$$x_{1}, x_{2}$$" in html


### PR DESCRIPTION
## Summary
- ensure detect_latex_parens strips any fully wrapped nested parentheses before converting to $$ blocks
- add regression test for double-parenthesized LaTeX

## Testing
- `pytest tests/test_latex_auto_detect.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3e58106848329847013d066c6c97c