### PR TITLE
Add admin feature to remove citations by URL

### DIFF
--- a/templates/admin/delete_citation_url.html
+++ b/templates/admin/delete_citation_url.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Delete Citations by URL') }}{% endblock %}
+{% block content %}
+<h1>{{ _('Delete Citations by URL') }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <input type="text" name="url" placeholder="{{ _('Citation URL') }}" class="form-control" />
+  </div>
+  <button type="submit" class="btn btn-danger">{{ _('Delete') }}</button>
+</form>
+{% endblock %}

--- a/tests/test_admin_delete_citation_by_url.py
+++ b/tests/test_admin_delete_citation_by_url.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db, User, Post, PostCitation
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        admin = User(username='admin', role='admin')
+        admin.set_password('pw')
+        db.session.add(admin)
+        post1 = Post(title='P1', body='Body', path='p1', language='en', author=admin)
+        post2 = Post(title='P2', body='Body', path='p2', language='en', author=admin)
+        db.session.add_all([post1, post2])
+        db.session.commit()
+        for post in (post1, post2):
+            db.session.add(PostCitation(
+                post_id=post.id,
+                user_id=admin.id,
+                citation_part={'title': 't', 'url': 'https://example.com'},
+                citation_text='https://example.com',
+                context='',
+                bibtex_raw='@article{a}',
+                bibtex_fields={'title': 't'},
+            ))
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def test_delete_citations_by_url(client):
+    client.post('/login', data={'username': 'admin', 'password': 'pw'})
+    resp = client.post(
+        '/admin/citations/delete-url',
+        data={'url': 'https://example.com'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert PostCitation.query.count() == 0


### PR DESCRIPTION
## Summary
- Add admin route and page to remove citations matching a URL
- Provide simple HTML form for admins to specify citation URL
- Cover URL deletion logic with new unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e830a00883298450c941587de6b2