### PR TITLE
fix: avoid converting latex inside dollar blocks

### DIFF
--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -25,3 +25,11 @@ def test_double_parenthesized_latex_converted():
     with app.app_context():
         html, _ = render_markdown(r"Coordinates ((x_{1}, x_{2})) test")
     assert "$$x_{1}, x_{2}$$" in html
+
+
+def test_dollar_wrapped_latex_preserved():
+    expr = r"$(\text{GDP} = \sum_{i}(\text{GVA}_i) + \text{Taxes} - \text{Subsidies})$"
+    with app.app_context():
+        html, _ = render_markdown(expr)
+    assert expr in html
+    assert '$$$' not in html


### PR DESCRIPTION
## Summary
- prevent detection logic from converting parentheses inside `$...$` or `$$...$$`
- add regression test ensuring dollar-delimited math is preserved
- sort tag posts by id for stable coordinate selection on tag map

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e78620a483299d305c416b2b204c