### PR TITLE
Refine parenthesized LaTeX detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -888,8 +888,8 @@ def detect_latex_parens(text: str) -> str:
     parentheses with ``$$`` so that MathJax treats them as math blocks.
 
     This detection is intentionally permissive – any parenthesized segment
-    without newlines that contains common LaTeX markers such as ``\``, ``_``
-    or ``^`` will be treated as LaTeX. Nested parentheses are supported so
+    without newlines that contains common LaTeX markers such as ``\``, ``_``,
+    ``{``, or ``}`` will be treated as LaTeX. Nested parentheses are supported so
     expressions like ``(U(x_{1},x_{2})=a x_{1}+b x_{2})`` are also converted.
     """
 
@@ -968,7 +968,7 @@ def detect_latex_parens(text: str) -> str:
                     depth -= 1
                     if depth == 0:
                         break
-                if c in '\\_^{}':
+                if c in '\\_{}':
                     is_latex = True
                 j += 1
             if depth == 0 and not has_newline and is_latex:

--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -33,3 +33,12 @@ def test_dollar_wrapped_latex_preserved():
         html, _ = render_markdown(expr)
     assert expr in html
     assert '$$$' not in html
+
+
+def test_caret_only_not_converted():
+    """Expressions with only ``^`` should not trigger LaTeX conversion."""
+
+    with app.app_context():
+        html, _ = render_markdown(r"Power (x^2) test")
+    assert "(x^2)" in html
+    assert "$$x^2$$" not in html


### PR DESCRIPTION
## Summary
- avoid treating parenthesized text as LaTeX when it only contains a caret
- document new detection markers and simplify LaTeX check
- add regression test ensuring caret-only text is left untouched

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb361e5c8329841766b0ead5452d