### PR TITLE
Use admin citation delete API

### DIFF
--- a/app.py
+++ b/app.py
@@ -3001,6 +3001,7 @@ def admin_delete_citation_url():
     if request.method == 'POST':
         url = request.form.get('url', '').strip()
         if url:
+            url = url.replace('\r\n', '\n')
             query = PostCitation.query.filter(
                 or_(
                     PostCitation.citation_text == url,

--- a/templates/citation_stats.html
+++ b/templates/citation_stats.html
@@ -14,11 +14,10 @@
         <a href="https://scholar.google.com/scholar?q={{ item.citation_text | urlencode }}">{{ item.citation_text }}</a>
       {% endif %}
       ({{ item.count }})
-      <form method="post" action="{{ url_for('delete_citation_everywhere') }}" class="d-inline ms-2" onsubmit="return confirm('{{ _('Are you sure?') }}');">
-        <input type="hidden" name="doi" value="{{ item.doi | default('') }}" />
-        <textarea name="citation_text" class="d-none">{{- item.citation_text -}}</textarea>
-        <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>
-      </form>
+        <form method="post" action="{{ url_for('admin_delete_citation_url') }}" class="d-inline ms-2" onsubmit="return confirm('{{ _('Are you sure?') }}');">
+          <textarea name="url" class="d-none">{{- item.citation_text -}}</textarea>
+          <button type="submit" class="btn btn-sm btn-danger">{{ _('Delete') }}</button>
+        </form>
     </td>
   </tr>
   <tr>

--- a/tests/test_citation_stats_delete.py
+++ b/tests/test_citation_stats_delete.py
@@ -42,8 +42,8 @@ def test_delete_citation_everywhere(client):
     resp = client.get('/citations/stats')
     assert b'Cite Me' in resp.data
     resp = client.post(
-        '/citations/delete',
-        data={'doi': '10.1234/abc', 'citation_text': 'Cite Me'},
+        '/admin/citations/delete-url',
+        data={'url': 'Cite Me'},
         follow_redirects=True,
     )
     assert resp.status_code == 200

--- a/tests/test_citation_stats_delete_newline.py
+++ b/tests/test_citation_stats_delete_newline.py
@@ -43,13 +43,13 @@ def test_delete_citation_with_newline(client):
     client.post('/login', data={'username': 'admin', 'password': 'pw'})
     resp = client.get('/citations/stats')
     html = resp.data.decode()
-    m = re.search(r'<textarea name="citation_text"[^>]*>(.*?)</textarea>', html, re.S)
+    m = re.search(r'<textarea name="url"[^>]*>(.*?)</textarea>', html, re.S)
     assert m is not None
     value = m.group(1)
     value = value.replace('\n', '\r\n')
     client.post(
-        '/citations/delete',
-        data={'doi': '10.1234/abc', 'citation_text': value},
+        '/admin/citations/delete-url',
+        data={'url': value},
         follow_redirects=True,
     )
     resp = client.get('/citations/stats')


### PR DESCRIPTION
## Summary
- Point citation stats delete button to `/admin/citations/delete-url` and send citation text as a URL
- Normalize newline sequences in admin delete API so citations with CRLF line endings can be removed
- Update citation stats tests for the new endpoint and parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb56270883299b5e9d4bfb4b7c9c