### PR TITLE
Handle LaTeX blocks in markdown rendering

### DIFF
--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -58,6 +58,12 @@ def test_render_markdown_preserves_multiline_mathjax():
     assert html.strip() == '$$\n\\int_0^1 x\\,dx\n$$'
 
 
+def test_render_markdown_preserves_complex_latex():
+    expr = '$$Y_t = Y^{*}_t + \\frac{1}{\\sigma}\\big(P_t - E_t P_{t+1}\\big)$$'
+    html, _ = render_markdown(expr)
+    assert html.strip() == expr
+
+
 def test_render_markdown_single_space_indented_list():
     """A single leading space should create a nested list."""
     html, _ = render_markdown('- a\n - b\n- c')


### PR DESCRIPTION
## Summary
- prevent markdown from mangling MathJax expressions by temporarily storing math segments
- test rendering of complex LaTeX macros

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3eccb0a1083298312b5ae051ee8f9