### PR TITLE
Handle inline $$ math delimiters in Markdown

### DIFF
--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -8,7 +8,7 @@ from app import app, render_markdown
 def test_parenthesized_latex_converted():
     with app.app_context():
         html, _ = render_markdown(r"Equation (\min\max_a) test")
-    assert "$$\\min\\max_a$$" in html
+    assert "\\(\\min\\max_a\\)" in html
 
 
 def test_nested_parenthesized_latex_converted():
@@ -16,7 +16,7 @@ def test_nested_parenthesized_latex_converted():
         html, _ = render_markdown(
             r"Substitutes, (U(x_{1},x_{2})=a x_{1}+b x_{2}), test"
         )
-    assert "$$U(x_{1},x_{2})=a x_{1}+b x_{2}$$" in html
+    assert "\\(U(x_{1},x_{2})=a x_{1}+b x_{2}\\)" in html
 
 
 def test_double_parenthesized_latex_converted():
@@ -24,7 +24,7 @@ def test_double_parenthesized_latex_converted():
 
     with app.app_context():
         html, _ = render_markdown(r"Coordinates ((x_{1}, x_{2})) test")
-    assert "$$x_{1}, x_{2}$$" in html
+    assert "\\(x_{1}, x_{2}\\)" in html
 
 
 def test_dollar_wrapped_latex_preserved():

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -64,6 +64,12 @@ def test_render_markdown_preserves_complex_latex():
     assert html.strip() == expr
 
 
+def test_render_markdown_converts_inline_double_dollar():
+    html, _ = render_markdown('with targets $$x=1$$, $$y=2$$ inside')
+    assert '\\(x=1\\)' in html
+    assert '\\(y=2\\)' in html
+
+
 def test_render_markdown_single_space_indented_list():
     """A single leading space should create a nested list."""
     html, _ = render_markdown('- a\n - b\n- c')


### PR DESCRIPTION
## Summary
- convert inline `$$..$$` segments to `\( .. \)` so MathJax renders math within sentences
- test conversion of inline double-dollar expressions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3efff31888329b5a00942d955ef85