### PR TITLE
Enable robust math rendering with MathJax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ Flask-SocketIO==5.5.1
 geopy==2.4.1
 habanero==2.3.0
 langdetect==1.0.9
-markdown==3.5.1
+markdown>=3
+pymdown-extensions>=10
 python-dotenv==1.0.1
 redis==5.0.0
 requests==2.31.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,14 +15,17 @@
   {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
   <script>
-    window.MathJax = {
-      tex: {
-        inlineMath: [['\\(', '\\)']],
-        displayMath: [['$$', '$$'], ['\\[', '\\]']]
-      }
-    };
+  window.MathJax = {
+    tex: {
+      inlineMath: [['\\(', '\\)'], ['$', '$']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+    }
+  };
   </script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">

--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -28,10 +28,11 @@ def test_double_parenthesized_latex_converted():
 
 
 def test_dollar_wrapped_latex_preserved():
-    expr = r"$(\text{GDP} = \sum_{i}(\text{GVA}_i) + \text{Taxes} - \text{Subsidies})$"
+    expr = r"$(\\text{GDP} = \\sum_{i}(\\text{GVA}_i) + \\text{Taxes} - \\text{Subsidies})$"
     with app.app_context():
         html, _ = render_markdown(expr)
-    assert expr in html
+    assert '<span class=\"arithmatex\">' in html
+    assert '\\text{GDP}' in html
     assert '$$$' not in html
 
 

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -50,24 +50,26 @@ def test_render_markdown_blank_numbered_item_becomes_unordered():
 
 def test_render_markdown_preserves_mathjax_delimiters():
     html, _ = render_markdown('Euler formula $e^{i\\pi}+1=0$')
-    assert '$e^{i\\pi}+1=0$' in html
+    assert '<span class="arithmatex">\\(e^{i\\pi}+1=0\\)</span>' in html
 
 
 def test_render_markdown_preserves_multiline_mathjax():
     html, _ = render_markdown('$$\n\\int_0^1 x\\,dx\n$$')
-    assert html.strip() == '$$\n\\int_0^1 x\\,dx\n$$'
+    expected = '<div class="arithmatex">\\[\n\\int_0^1 x\\,dx\n\\]</div>'
+    assert html.strip() == expected
 
 
 def test_render_markdown_preserves_complex_latex():
     expr = '$$Y_t = Y^{*}_t + \\frac{1}{\\sigma}\\big(P_t - E_t P_{t+1}\\big)$$'
     html, _ = render_markdown(expr)
-    assert html.strip() == expr
+    expected = '<div class="arithmatex">\\[Y_t = Y^{*}_t + \\frac{1}{\\sigma}\\big(P_t - E_t P_{t+1}\\big)\\]</div>'
+    assert html.strip() == expected
 
 
 def test_render_markdown_converts_inline_double_dollar():
     html, _ = render_markdown('with targets $$x=1$$, $$y=2$$ inside')
-    assert '\\(x=1\\)' in html
-    assert '\\(y=2\\)' in html
+    assert '<span class="arithmatex">\\(x=1\\)</span>' in html
+    assert '<span class="arithmatex">\\(y=2\\)</span>' in html
 
 
 def test_render_markdown_single_space_indented_list():

--- a/tests/test_tag_links_in_latex.py
+++ b/tests/test_tag_links_in_latex.py
@@ -31,8 +31,8 @@ def test_tag_links_skipped_inside_latex(monkeypatch):
         html, _ = render_markdown('$$foo$$ and foo')
 
     assert 'class="tag-link"' in html
-    assert '$$<a' not in html
-    assert '$$foo$$' in html
+    assert '<span class="arithmatex">\\(foo\\)</span>' in html
+    assert '<span class="arithmatex"><a' not in html
 
 
 def test_tag_links_skipped_inside_detected_latex(monkeypatch):
@@ -58,5 +58,5 @@ def test_tag_links_skipped_inside_detected_latex(monkeypatch):
         html, _ = render_markdown('(foo(x_{1},x_{2})=a x_{1}+b x_{2}) and foo')
 
     assert 'class="tag-link"' in html
-    assert '$$<a' not in html
-    assert '$$foo(x_{1},x_{2})=a x_{1}+b x_{2}$$' in html
+    assert '<span class="arithmatex">\\(foo(x_{1},x_{2})=a x_{1}+b x_{2}\\)</span>' in html
+    assert '<span class="arithmatex"><a' not in html


### PR DESCRIPTION
## Summary
- add pymdownx.arithmatex extension and return Markup for safe math HTML
- configure MathJax to support \(\), $…$, \[\], and $$…$$ delimiters
- update tests for new math rendering pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f4087ef08329bf70ebc1f2ddd478