### PR TITLE
Simplify MathJax configuration

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,9 +19,6 @@
     tex: {
       inlineMath: [['\\(', '\\)'], ['$', '$']],
       displayMath: [['$$', '$$'], ['\\[', '\\]']]
-    },
-    options: {
-      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
     }
   };
   </script>


### PR DESCRIPTION
## Summary
- streamline MathJax config to focus on inline and display delimiters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a41223f2548329a0294b43dec2d667