### PR TITLE
Add toggle to disable MathJax

### DIFF
--- a/API.md
+++ b/API.md
@@ -178,7 +178,7 @@ and `radius`.
 
 ### `/settings` (`GET, POST`)
 View or update user settings. POST accepts various configuration fields such as
-`home_page_path` or `rss_enabled`.
+`home_page_path`, `rss_enabled`, or `mathjax_enabled`.
 
 ### `/geocode` (`GET`)
 Return coordinates for the provided `address` query parameter.

--- a/app.py
+++ b/app.py
@@ -2632,6 +2632,7 @@ def settings():
     head_tags = get_setting('head_tags', '')
     category_tags = get_setting('post_categories', '')
     breadcrumb_limit = get_setting('breadcrumb_limit', '10')
+    mathjax_enabled_val = get_setting('mathjax_enabled', 'false')
     if request.method == 'POST':
 
         title = request.form.get('site_title', title).strip()
@@ -2644,6 +2645,7 @@ def settings():
             return redirect(url_for('settings'))
         timezone_value = tz_norm
         rss_enabled_val = 'rss_enabled' in request.form
+        mathjax_enabled_val = 'mathjax_enabled' in request.form
         rss_limit = request.form.get('rss_limit', rss_limit).strip() or '20'
         breadcrumb_limit = request.form.get('breadcrumb_limit', breadcrumb_limit).strip() or '10'
         head_tags_input = request.form.get('head_tags', head_tags)
@@ -2712,6 +2714,12 @@ def settings():
             breadcrumb_setting.value = breadcrumb_limit
         else:
             db.session.add(Setting(key='breadcrumb_limit', value=breadcrumb_limit))
+        mathjax_setting = Setting.query.filter_by(key='mathjax_enabled').first()
+        mathjax_value = 'true' if mathjax_enabled_val else 'false'
+        if mathjax_setting:
+            mathjax_setting.value = mathjax_value
+        else:
+            db.session.add(Setting(key='mathjax_enabled', value=mathjax_value))
 
         db.session.commit()
         flash(_('Settings updated.'))
@@ -2726,7 +2734,8 @@ def settings():
         rss_limit=rss_limit,
         head_tags=head_tags,
         post_categories=category_tags,
-        breadcrumb_limit=breadcrumb_limit
+        breadcrumb_limit=breadcrumb_limit,
+        mathjax_enabled=mathjax_enabled_val.lower() in ['true', '1', 'yes', 'on']
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
   <link rel="canonical" href="{{ canonical_url|default(request.url, true) }}">
   {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
+  {% if get_setting('mathjax_enabled', 'false').lower() in ['true', '1', 'yes', 'on'] %}
   <script>
   window.MathJax = {
     tex: {
@@ -23,6 +24,7 @@
   };
   </script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+  {% endif %}
 </head>
 <body>
 <nav class="navbar navbar-expand-lg">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,6 +29,10 @@
         <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
         <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
       </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="mathjax_enabled" name="mathjax_enabled" {% if mathjax_enabled %}checked{% endif %}>
+      <label class="form-check-label" for="mathjax_enabled">{{ _('Enable MathJax') }}</label>
+    </div>
       <div class="mb-3">
         <label for="breadcrumb_limit" class="form-label">{{ _('Reading history limit') }}</label>
         <input type="number" id="breadcrumb_limit" name="breadcrumb_limit" class="form-control" value="{{ breadcrumb_limit }}">


### PR DESCRIPTION
## Summary
- Add `mathjax_enabled` setting stored in database
- Gate MathJax scripts on new setting so it can be disabled
- Document new setting in API guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a422ae2fcc8329a5dc7bd8c4a96402