### PR TITLE
Allow tag-based MathJax and parentheses conversion

### DIFF
--- a/API.md
+++ b/API.md
@@ -178,7 +178,7 @@ and `radius`.
 
 ### `/settings` (`GET, POST`)
 View or update user settings. POST accepts various configuration fields such as
-`home_page_path`, `rss_enabled`, or `mathjax_enabled`.
+`home_page_path`, `rss_enabled`, `mathjax_tags`, or `paren_tags`.
 
 ### `/geocode` (`GET`)
 Return coordinates for the provided `address` query parameter.

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
   <link rel="canonical" href="{{ canonical_url|default(request.url, true) }}">
   {% block extra_head %}{% endblock %}
   {{ get_setting('head_tags')|safe }}
-  {% if get_setting('mathjax_enabled', 'false').lower() in ['true', '1', 'yes', 'on'] %}
+  {% if mathjax_enabled|default(false) %}
   <script>
   window.MathJax = {
     tex: {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,9 +29,15 @@
         <label for="rss_limit" class="form-label">{{ _('RSS items limit') }}</label>
         <input type="number" id="rss_limit" name="rss_limit" class="form-control" value="{{ rss_limit }}">
       </div>
-    <div class="form-check mb-3">
-      <input class="form-check-input" type="checkbox" id="mathjax_enabled" name="mathjax_enabled" {% if mathjax_enabled %}checked{% endif %}>
-      <label class="form-check-label" for="mathjax_enabled">{{ _('Enable MathJax') }}</label>
+    <div class="mb-3">
+      <label for="mathjax_tags" class="form-label">{{ _('MathJax tags') }}</label>
+      <input type="text" id="mathjax_tags" name="mathjax_tags" class="form-control" value="{{ mathjax_tags }}">
+      <div class="form-text">{{ _('Comma-separated tags that enable MathJax') }}</div>
+    </div>
+    <div class="mb-3">
+      <label for="paren_tags" class="form-label">{{ _('Parentheses to \\(\\) tags') }}</label>
+      <input type="text" id="paren_tags" name="paren_tags" class="form-control" value="{{ paren_tags }}">
+      <div class="form-text">{{ _('Comma-separated tags to convert parentheses to \\(\\)') }}</div>
     </div>
       <div class="mb-3">
         <label for="breadcrumb_limit" class="form-label">{{ _('Reading history limit') }}</label>

--- a/tests/test_latex_auto_detect.py
+++ b/tests/test_latex_auto_detect.py
@@ -7,14 +7,15 @@ from app import app, render_markdown
 
 def test_parenthesized_latex_converted():
     with app.app_context():
-        html, _ = render_markdown(r"Equation (\min\max_a) test")
+        html, _ = render_markdown(r"Equation (\min\max_a) test", enable_mathjax=True)
     assert "\\(\\min\\max_a\\)" in html
 
 
 def test_nested_parenthesized_latex_converted():
     with app.app_context():
         html, _ = render_markdown(
-            r"Substitutes, (U(x_{1},x_{2})=a x_{1}+b x_{2}), test"
+            r"Substitutes, (U(x_{1},x_{2})=a x_{1}+b x_{2}), test",
+            enable_mathjax=True,
         )
     assert "\\(U(x_{1},x_{2})=a x_{1}+b x_{2}\\)" in html
 
@@ -23,14 +24,14 @@ def test_double_parenthesized_latex_converted():
     """Ensure outer nested parentheses are fully stripped."""
 
     with app.app_context():
-        html, _ = render_markdown(r"Coordinates ((x_{1}, x_{2})) test")
+        html, _ = render_markdown(r"Coordinates ((x_{1}, x_{2})) test", enable_mathjax=True)
     assert "\\(x_{1}, x_{2}\\)" in html
 
 
 def test_dollar_wrapped_latex_preserved():
     expr = r"$(\\text{GDP} = \\sum_{i}(\\text{GVA}_i) + \\text{Taxes} - \\text{Subsidies})$"
     with app.app_context():
-        html, _ = render_markdown(expr)
+        html, _ = render_markdown(expr, enable_mathjax=True)
     assert '<span class=\"arithmatex\">' in html
     assert '\\text{GDP}' in html
     assert '$$$' not in html
@@ -40,6 +41,6 @@ def test_caret_only_not_converted():
     """Expressions with only ``^`` should not trigger LaTeX conversion."""
 
     with app.app_context():
-        html, _ = render_markdown(r"Power (x^2) test")
+        html, _ = render_markdown(r"Power (x^2) test", enable_mathjax=True)
     assert "(x^2)" in html
     assert "$$x^2$$" not in html

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -49,25 +49,25 @@ def test_render_markdown_blank_numbered_item_becomes_unordered():
 
 
 def test_render_markdown_preserves_mathjax_delimiters():
-    html, _ = render_markdown('Euler formula $e^{i\\pi}+1=0$')
+    html, _ = render_markdown('Euler formula $e^{i\\pi}+1=0$', enable_mathjax=True)
     assert '<span class="arithmatex">\\(e^{i\\pi}+1=0\\)</span>' in html
 
 
 def test_render_markdown_preserves_multiline_mathjax():
-    html, _ = render_markdown('$$\n\\int_0^1 x\\,dx\n$$')
+    html, _ = render_markdown('$$\n\\int_0^1 x\\,dx\n$$', enable_mathjax=True)
     expected = '<div class="arithmatex">\\[\n\\int_0^1 x\\,dx\n\\]</div>'
     assert html.strip() == expected
 
 
 def test_render_markdown_preserves_complex_latex():
     expr = '$$Y_t = Y^{*}_t + \\frac{1}{\\sigma}\\big(P_t - E_t P_{t+1}\\big)$$'
-    html, _ = render_markdown(expr)
+    html, _ = render_markdown(expr, enable_mathjax=True)
     expected = '<div class="arithmatex">\\[Y_t = Y^{*}_t + \\frac{1}{\\sigma}\\big(P_t - E_t P_{t+1}\\big)\\]</div>'
     assert html.strip() == expected
 
 
 def test_render_markdown_converts_inline_double_dollar():
-    html, _ = render_markdown('with targets $$x=1$$, $$y=2$$ inside')
+    html, _ = render_markdown('with targets $$x=1$$, $$y=2$$ inside', enable_mathjax=True)
     assert '<span class="arithmatex">\\(x=1\\)</span>' in html
     assert '<span class="arithmatex">\\(y=2\\)</span>' in html
 

--- a/tests/test_tag_links_in_latex.py
+++ b/tests/test_tag_links_in_latex.py
@@ -28,7 +28,7 @@ def test_tag_links_skipped_inside_latex(monkeypatch):
     monkeypatch.setattr(app_module, 'get_tag_synonyms', lambda name: {name})
 
     with app.app_context():
-        html, _ = render_markdown('$$foo$$ and foo')
+        html, _ = render_markdown('$$foo$$ and foo', enable_mathjax=True)
 
     assert 'class="tag-link"' in html
     assert '<span class="arithmatex">\\(foo\\)</span>' in html
@@ -55,7 +55,7 @@ def test_tag_links_skipped_inside_detected_latex(monkeypatch):
     monkeypatch.setattr(app_module, 'get_tag_synonyms', lambda name: {name})
 
     with app.app_context():
-        html, _ = render_markdown('(foo(x_{1},x_{2})=a x_{1}+b x_{2}) and foo')
+        html, _ = render_markdown('(foo(x_{1},x_{2})=a x_{1}+b x_{2}) and foo', enable_mathjax=True)
 
     assert 'class="tag-link"' in html
     assert '<span class="arithmatex">\\(foo(x_{1},x_{2})=a x_{1}+b x_{2}\\)</span>' in html


### PR DESCRIPTION
## Summary
- add settings for `mathjax_tags` and `paren_tags` to toggle math features per tag
- enable MathJax only when posts have configured tags
- allow optional math processing via new `render_markdown(..., enable_mathjax=True)` parameter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a437c014bc83299640c58ae405cf2b