### PR TITLE
Condense pagination display for posts listing

### DIFF
--- a/templates/admin/posts.html
+++ b/templates/admin/posts.html
@@ -38,9 +38,19 @@
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('admin_posts', page=pagination.prev_num, q=q) }}">&laquo;</a>
     </li>
-    {% for p in range(1, pagination.pages + 1) %}
-    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('admin_posts', page=p, q=q) }}">{{ p }}</a></li>
-    {% endfor %}
+    {% if pagination.pages <= 7 %}
+      {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('admin_posts', page=p, q=q) }}">{{ p }}</a></li>
+      {% endfor %}
+    {% else %}
+      {% for p in pagination.iter_pages(left_edge=2, right_edge=2, left_current=2, right_current=2) %}
+        {% if p %}
+        <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('admin_posts', page=p, q=q) }}">{{ p }}</a></li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('admin_posts', page=pagination.next_num, q=q) }}">&raquo;</a>
     </li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,9 +30,23 @@
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('all_posts', page=pagination.prev_num, tag=tag.name if tag else None) }}">&laquo;</a>
     </li>
-    {% for p in range(1, pagination.pages + 1) %}
-    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('all_posts', page=p, tag=tag.name if tag else None) }}">{{ p }}</a></li>
-    {% endfor %}
+    {% if pagination.pages <= 7 %}
+      {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item{% if p == pagination.page %} active{% endif %}">
+        <a class="page-link" href="{{ url_for('all_posts', page=p, tag=tag.name if tag else None) }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+    {% else %}
+      {% for p in pagination.iter_pages(left_edge=2, right_edge=2, left_current=2, right_current=2) %}
+        {% if p %}
+        <li class="page-item{% if p == pagination.page %} active{% endif %}">
+          <a class="page-link" href="{{ url_for('all_posts', page=p, tag=tag.name if tag else None) }}">{{ p }}</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('all_posts', page=pagination.next_num, tag=tag.name if tag else None) }}">&raquo;</a>
     </li>

--- a/templates/search.html
+++ b/templates/search.html
@@ -61,9 +61,19 @@
     <li class="page-item{% if not pagination.has_prev %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('search', page=pagination.prev_num, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">&laquo;</a>
     </li>
-    {% for p in range(1, pagination.pages + 1) %}
-    <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('search', page=p, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">{{ p }}</a></li>
-    {% endfor %}
+    {% if pagination.pages <= 7 %}
+      {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('search', page=p, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">{{ p }}</a></li>
+      {% endfor %}
+    {% else %}
+      {% for p in pagination.iter_pages(left_edge=2, right_edge=2, left_current=2, right_current=2) %}
+        {% if p %}
+        <li class="page-item{% if p == pagination.page %} active{% endif %}"><a class="page-link" href="{{ url_for('search', page=p, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">{{ p }}</a></li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     <li class="page-item{% if not pagination.has_next %} disabled{% endif %}">
       <a class="page-link" href="{{ url_for('search', page=pagination.next_num, q=q, tags=tags, key=key, value=value, lat=lat, lon=lon, radius=radius) }}">&raquo;</a>
     </li>


### PR DESCRIPTION
## Summary
- Condense all post, search, and admin pagination using `iter_pages` with ellipsis
- Show ellipsis placeholders when total page count is large

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a457b047f88329a921285ea72d5ef5