### PR TITLE
Show distances on tag tooltips with user unit preference

### DIFF
--- a/models.py
+++ b/models.py
@@ -33,6 +33,7 @@ class User(UserMixin, db.Model):
     locale = db.Column(db.String(8))
     timezone = db.Column(db.String(50), default="UTC")
     tag_modal_new_tab = db.Column(db.Boolean, default=False)
+    distance_unit = db.Column(db.String(5), default="km")
 
     def set_password(self, password: str) -> None:
         self.password_hash = generate_password_hash(password)

--- a/static/tag-tooltip.js
+++ b/static/tag-tooltip.js
@@ -6,6 +6,28 @@ document.addEventListener('DOMContentLoaded', () => {
   let hideTimeout;
   let leafletPromise;
 
+  function haversine(lat1, lon1, lat2, lon2) {
+    const R = 6371;
+    const toRad = deg => (deg * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(toRad(lat1)) *
+        Math.cos(toRad(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
+
+  function formatDistance(km) {
+    if (distanceUnit === 'mi') {
+      return `${(km * 0.621371).toFixed(1)} mi`;
+    }
+    return `${km.toFixed(1)} km`;
+  }
+
   function loadLeaflet() {
     if (leafletPromise) return leafletPromise;
     leafletPromise = new Promise(resolve => {
@@ -53,7 +75,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const mapDiv = d.lat !== undefined && d.lon !== undefined
           ? `<div class="tooltip-map" id="tooltip-map-${i}" data-lat="${d.lat}" data-lon="${d.lon}"></div>`
           : '';
-        const views = d.views !== undefined ? `<div class="small text-muted">${d.views} views</div>` : '';
+        let distanceText = '';
+        if (
+          typeof currentLat === 'number' &&
+          typeof currentLon === 'number' &&
+          d.lat !== undefined &&
+          d.lon !== undefined
+        ) {
+          const km = haversine(currentLat, currentLon, d.lat, d.lon);
+          distanceText = ` \u2022 ${formatDistance(km)}`;
+        }
+        const views = d.views !== undefined ? `<div class="small text-muted">${d.views} views${distanceText}</div>` : '';
         return `<div class="tag-doc">${mapDiv}<div class="tag-doc-text"><a href="${d.url}">${d.title}</a>${views}<p>${d.snippet}</p></div></div>`;
       })
       .join('');

--- a/templates/base.html
+++ b/templates/base.html
@@ -258,8 +258,13 @@
       const url = window.location.href;
       window.prompt('{{ _("Copy permalink") }}', url);
     });
-    heading.appendChild(btn);
+  heading.appendChild(btn);
   });
+</script>
+<script>
+  const currentLat = {{ lat|default(none)|tojson }};
+  const currentLon = {{ lon|default(none)|tojson }};
+  const distanceUnit = {{ (current_user.distance_unit if current_user.is_authenticated and current_user.distance_unit else 'km')|tojson }};
 </script>
 <script src="{{ url_for('static', filename='tag-tooltip.js') }}"></script>
 </body>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -5,6 +5,7 @@
 <p>{{ user.bio }}</p>
 {% if user.locale %}<p>{{ _('Locale') }}: {{ user.locale }}</p>{% endif %}
 {% if user.timezone %}<p>{{ _('Timezone') }}: {{ user.timezone }}</p>{% endif %}
+{% if user.distance_unit %}<p>{{ _('Distance Unit') }}: {{ user.distance_unit }}</p>{% endif %}
 <section>
   <h2>{{ _('Contribution Metrics') }}</h2>
   <div class="row row-cols-1 row-cols-sm-2 g-4">
@@ -102,14 +103,21 @@
         {% endfor %}
       </select>
     </div>
-    <div class="mb-3">
-      <label for="timezone" class="form-label">{{ _('Timezone') }}</label>
-      <input type="text" id="timezone" name="timezone" class="form-control" value="{{ user.timezone or '' }}">
-    </div>
-    <div class="form-check mb-3">
-      <input class="form-check-input" type="checkbox" id="tag_modal_new_tab" name="tag_modal_new_tab" {% if user.tag_modal_new_tab %}checked{% endif %}>
-      <label class="form-check-label" for="tag_modal_new_tab">{{ _('Open tag links in new tab') }}</label>
-    </div>
+      <div class="mb-3">
+        <label for="timezone" class="form-label">{{ _('Timezone') }}</label>
+        <input type="text" id="timezone" name="timezone" class="form-control" value="{{ user.timezone or '' }}">
+      </div>
+      <div class="mb-3">
+        <label for="distance_unit" class="form-label">{{ _('Distance Unit') }}</label>
+        <select id="distance_unit" name="distance_unit" class="form-select">
+          <option value="km" {% if user.distance_unit != 'mi' %}selected{% endif %}>{{ _('Kilometers') }}</option>
+          <option value="mi" {% if user.distance_unit == 'mi' %}selected{% endif %}>{{ _('Miles') }}</option>
+        </select>
+      </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" id="tag_modal_new_tab" name="tag_modal_new_tab" {% if user.tag_modal_new_tab %}checked{% endif %}>
+        <label class="form-check-label" for="tag_modal_new_tab">{{ _('Open tag links in new tab') }}</label>
+      </div>
     <div class="mb-3">
       <button type="submit" class="btn btn-primary">{{ _('Update') }}</button>
     </div>


### PR DESCRIPTION
## Summary
- allow users to choose km or miles as a distance unit
- display distance between current document and tag tooltip entries when coordinates are available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a45b730b488329accbdd3fa6319a24