### PR TITLE
Add keyword highlighting plugin for markdown rendering

### DIFF
--- a/keyword_highlight_plugin.py
+++ b/keyword_highlight_plugin.py
@@ -1,0 +1,61 @@
+import re
+from typing import List, Tuple
+import yake
+
+
+def _insert_tags(html_content: str, spans: List[Tuple[int, int]]) -> str:
+    result: List[str] = []
+    plain_idx = 0
+    span_iter = iter(sorted(spans, key=lambda s: s[0]))
+    current = next(span_iter, None)
+    i = 0
+    while i < len(html_content):
+        if current and plain_idx == current[1]:
+            result.append('</strong></u>')
+            current = next(span_iter, None)
+            continue
+        if html_content[i] == '<':
+            j = html_content.find('>', i) + 1
+            result.append(html_content[i:j])
+            i = j
+            continue
+        if current and plain_idx == current[0]:
+            result.append('<u><strong>')
+        result.append(html_content[i])
+        plain_idx += 1
+        i += 1
+    if current and plain_idx == current[1]:
+        result.append('</strong></u>')
+    return ''.join(result)
+
+
+def apply_keyword_highlight_plugin(html: str, language: str = 'en') -> str:
+    extractor = None
+    try:
+        extractor = yake.KeywordExtractor(lan=language, n=1, top=1)
+    except Exception:
+        extractor = yake.KeywordExtractor(lan='en', n=1, top=1)
+
+    def process(match: re.Match[str]) -> str:
+        content = match.group(1)
+        text = re.sub('<[^<]+?>', '', content)
+        text = text.strip()
+        if not text:
+            return match.group(0)
+        try:
+            keyword = extractor.extract_keywords(text)[0][0]
+        except Exception:
+            return match.group(0)
+        spans: List[Tuple[int, int]] = []
+        for m in re.finditer(r'[^.!?]+[.!?]?', text):
+            sent = m.group().strip()
+            if keyword.lower() in sent.lower():
+                spans.append((m.start(), m.end()))
+        if not spans:
+            new_content = f'[{keyword}] {content}'
+            return f'<p>{new_content}</p>'
+        highlighted = _insert_tags(content, spans)
+        new_content = f'[{keyword}] {highlighted}'
+        return f'<p>{new_content}</p>'
+
+    return re.sub(r'<p>(.*?)</p>', process, html, flags=re.DOTALL)

--- a/models.py
+++ b/models.py
@@ -34,6 +34,7 @@ class User(UserMixin, db.Model):
     timezone = db.Column(db.String(50), default="UTC")
     tag_modal_new_tab = db.Column(db.Boolean, default=False)
     distance_unit = db.Column(db.String(5), default="km")
+    keyword_highlight_plugin = db.Column(db.Boolean, default=True)
 
     def set_password(self, password: str) -> None:
         self.password_hash = generate_password_hash(password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ redis==5.0.0
 requests==2.31.0
 tzdata==2025.2
 nltk==3.8.1
+yake==0.4.8

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -118,6 +118,10 @@
         <input class="form-check-input" type="checkbox" id="tag_modal_new_tab" name="tag_modal_new_tab" {% if user.tag_modal_new_tab %}checked{% endif %}>
         <label class="form-check-label" for="tag_modal_new_tab">{{ _('Open tag links in new tab') }}</label>
       </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" id="keyword_highlight_plugin" name="keyword_highlight_plugin" {% if user.keyword_highlight_plugin %}checked{% endif %}>
+        <label class="form-check-label" for="keyword_highlight_plugin">{{ _('Enable keyword sentence highlight') }}</label>
+      </div>
     <div class="mb-3">
       <button type="submit" class="btn btn-primary">{{ _('Update') }}</button>
     </div>

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -99,12 +99,12 @@ def client():
 
 def test_markdown_preview_language(client):
     resp = client.post('/markdown/preview', json={'text': '[[Page]]', 'language': 'es'})
-    assert resp.get_json()['html'] == '<p><a href="/es/Page">Page</a></p>'
+    assert resp.get_json()['html'] == '<p>[Page] <a href="/es/Page"><u><strong>Page</strong></u></a></p>'
 
 
 def test_markdown_preview_renders_html(client):
     resp = client.post('/markdown/preview', json={'text': '<b>bold</b>'})
-    assert resp.get_json()['html'] == '<p><b>bold</b></p>'
+    assert resp.get_json()['html'] == '<p>[bold] <b><u><strong>bold</strong></u></b></p>'
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Extract the most relevant keyword from each Markdown paragraph via YAKE
- Highlight sentences containing that keyword in bold and underline, prefixed by the keyword
- Allow users to toggle the feature in profile settings (on by default)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46b457e4c8329891be2580f04b0a2