### PR TITLE
docs: add third-party license documentation

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,6 +2,24 @@
 
 This project uses the following third-party libraries:
 
-- **langdetect** – MIT License
-- **JSONEditor** – MIT License
+| Library | License |
+| --- | --- |
+| bibtexparser | LGPLv3 or BSD-3-Clause |
+| Flask | BSD-3-Clause |
+| Flask-Babel | BSD-3-Clause |
+| Flask-Login | MIT License |
+| Flask-SQLAlchemy | BSD-3-Clause |
+| Flask-SocketIO | MIT License |
+| geopy | MIT License |
+| habanero | MIT License |
+| JSONEditor | MIT License |
+| langdetect | MIT License |
+| Markdown | BSD-3-Clause |
+| nltk | Apache License 2.0 |
+| pymdown-extensions | MIT License |
+| python-dotenv | BSD-3-Clause |
+| redis | MIT License |
+| requests | Apache License 2.0 |
+| tzdata | Apache License 2.0 |
+| yake | LGPLv3 |
 


### PR DESCRIPTION
## Summary
- document licenses for project dependencies in `THIRD_PARTY_LICENSES.md`

## Testing
- `pytest tests/test_admin_db_status.py`
- `pytest` *(interrupted: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68a475782c208329b63756c049db2477